### PR TITLE
Feature/in game UI

### DIFF
--- a/Content/Team02/AIBossMonster/BP_TAIBossMonster.uasset
+++ b/Content/Team02/AIBossMonster/BP_TAIBossMonster.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6aa9b3402fcbf824438b0c409537f33fb98c372e953fffdc666563e927f50f6c
-size 33828
+oid sha256:b5eb3f424349de625ade4117adbe14ebfeb32fa6c818acae406b72c519962e42
+size 35943

--- a/Content/Team02/Maps/PlayGround.umap
+++ b/Content/Team02/Maps/PlayGround.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12597d288884edc6273f54a88e3cdcb8d4aeb8923adc082c954ef04fb5d8852c
+oid sha256:90c29c554fdb3ce5443f4fa1843fd47126c687f46465a41cc9769f6d8f1c1c38
 size 100897

--- a/Content/Team02/Maps/PlayGround.umap
+++ b/Content/Team02/Maps/PlayGround.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:009154e9e52028a5f0093aac1c7c97e3cbe2a1658df5d1b5da2ffc91c1efa7be
-size 115768
+oid sha256:090c285554eb12eacd297af6c9209f2a1abf586430be1519ae0f3289c3549239
+size 103278

--- a/Content/Team02/Maps/PlayGround.umap
+++ b/Content/Team02/Maps/PlayGround.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eecea1d34ba084bb6e6cd3cadd435022e335f9bf916c267883be5d7740fafde9
-size 98473
+oid sha256:12597d288884edc6273f54a88e3cdcb8d4aeb8923adc082c954ef04fb5d8852c
+size 100897

--- a/Content/Team02/Maps/PlayGround.umap
+++ b/Content/Team02/Maps/PlayGround.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90c29c554fdb3ce5443f4fa1843fd47126c687f46465a41cc9769f6d8f1c1c38
-size 100897
+oid sha256:090c285554eb12eacd297af6c9209f2a1abf586430be1519ae0f3289c3549239
+size 103278

--- a/Content/Team02/Monster/GunNPC/Blueprint/BP_GunNPC.uasset
+++ b/Content/Team02/Monster/GunNPC/Blueprint/BP_GunNPC.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de199596b4db597c624c05fdfaa5c75daffb17b45c3c76a0d94fe43bc14ce4a6
-size 37470
+oid sha256:2af8d5132c7dbe7310161b922b5bd3d2b08f9b5c7c10be7d12e54cc7caca514d
+size 38516

--- a/Content/Team02/UI/InGame/BP_TCapturePoint_Test.uasset
+++ b/Content/Team02/UI/InGame/BP_TCapturePoint_Test.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:811dbd05bcc9d757e505a703c952505704360b164cb6919444f4cccbbe81f66d
+size 23426

--- a/Content/Team02/UI/InGame/WBP_BossHealthBar.uasset
+++ b/Content/Team02/UI/InGame/WBP_BossHealthBar.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04c907e029bf019c8830e77d9f0137c423bcc48b3283199cd98a788a395dcb88
+size 30271

--- a/Content/Team02/UI/InGame/WBP_MonsterHealthBar.uasset
+++ b/Content/Team02/UI/InGame/WBP_MonsterHealthBar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbe37cf2a37b3bb5c316d3af44c9bd8959c7885ba870a0eb85e558c58d1637e4
-size 26684
+oid sha256:152acba62a073c9e83db498edca90528a7bd392d71dab4b6da40e325094adce3
+size 32465

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67f5824f2118081f8a8c18f6b861bd2a5e91c3f84787f1c6a9a7fca775eb758a
-size 51561
+oid sha256:17e3720ed66956557ecdff90d837d5a09e0e6507e6cb1beff6dca7534070f254
+size 50796

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17e3720ed66956557ecdff90d837d5a09e0e6507e6cb1beff6dca7534070f254
-size 50796
+oid sha256:1cb5cd06ff0468c2440ee9ebfb6713acb03202d47b3356c125213b1cdd2a6cd5
+size 51662

--- a/Source/Team02/TGameState.cpp
+++ b/Source/Team02/TGameState.cpp
@@ -13,16 +13,7 @@ void ATGameState::BeginPlay()
 	Super::BeginPlay();
 
 	GameStart();
-
-	// 위젯 갱신
-	// GetWorldTimerManager().SetTimer().Timer(
-	// 	HUDUpdateTimerHandle,
-	// 	this,
-	// 	&ATGameState::UpdateHUD,
-	// 	0.1f,
-	// 	true
-	// 	);
-
+	
 }
 
 void ATGameState::GameStart()
@@ -36,17 +27,7 @@ void ATGameState::GameStart()
 	// 스폰 볼륨을 통해 아이템을 불러오는 코드 필요
 
 	// 제한 시간이 있다면 이를 조정하는 코드 필요
-	//웨이브 타이머 시작
-	bWaveActive = true;
 	
-	GetWorldTimerManager().SetTimer(
-		GameTimerHandle,
-		this,
-		&ATGameState::UpdateWaveTime,
-		1.0f,
-		true
-		);
-
 	// 마지막으로 HUD 업데이트 코드 필요
 }
 
@@ -67,31 +48,6 @@ void ATGameState::GameEnd()
 	// 플레이어 컨트롤러에서 Restart와 Exit 버튼이 포함된 End 메뉴를 보여주는 코드 필요
 	
 }
-
-void ATGameState::UpdateWaveTime()
-{
-	if (!bWaveActive) return; // 웨이브 활성화되지않으면 실행 X
-	WaveTime-=1.0f;
-	OnGameTimeUpdate.Broadcast(WaveTime);
-
-	if (WaveTime<=0.0f)
-	{
-		WaveTimeUp(); // 웨이브 종료
-	}
-}
-FString ATGameState::GetFormattedTime() const
-{
-	int32 Minutes=FMath::FloorToInt(WaveTime/60.0f);
-	int32 Seconds=FMath::FloorToInt(WaveTime) % 60;
-
-	return FString::Printf(TEXT("%02d:%02d"), Minutes, Seconds);
-}
-
-void ATGameState::WaveTimeUp()
-{
-	bWaveActive=false;
-}
-
 
 void ATGameState::UpdateHUD()
 {

--- a/Source/Team02/TGameState.cpp
+++ b/Source/Team02/TGameState.cpp
@@ -12,7 +12,44 @@ void ATGameState::BeginPlay()
 {
 	Super::BeginPlay();
 
+	GameStart();
 	
-
 }
 
+void ATGameState::GameStart()
+{
+	// 플레이어 컨트롤러와 HUD와 연결하는 코드 필요
+
+	// 게임 인스턴스를 가져오는 코드 필요
+
+	// Count와 관련된 기능들을 초기화하는 코드 필요
+
+	// 스폰 볼륨을 통해 아이템을 불러오는 코드 필요
+
+	// 제한 시간이 있다면 이를 조정하는 코드 필요
+	
+	// 마지막으로 HUD 업데이트 코드 필요
+}
+
+void ATGameState::GameClear()
+{
+	// 보스를 잡았을 때 클리어
+}
+
+void ATGameState::GameOver()
+{
+	// 게임 인스턴스 코드 필요
+}
+
+void ATGameState::GameEnd()
+{
+	// 게임을 멈추는 코드 필요
+
+	// 플레이어 컨트롤러에서 Restart와 Exit 버튼이 포함된 End 메뉴를 보여주는 코드 필요
+	
+}
+
+void ATGameState::UpdateHUD()
+{
+	// 위젯용 텍스트 코드 필요
+}

--- a/Source/Team02/TGameState.h
+++ b/Source/Team02/TGameState.h
@@ -6,8 +6,6 @@
 #include "GameFramework/GameState.h"
 #include "TGameState.generated.h"
 
-
-
 UCLASS()
 class TEAM02_API ATGameState : public AGameState
 {
@@ -16,6 +14,15 @@ class TEAM02_API ATGameState : public AGameState
 public:
 	ATGameState();
 	virtual void BeginPlay() override;
-
 	
+	UFUNCTION(BlueprintCallable, Category="Game State")
+	void GameOver();
+	UFUNCTION(BlueprintCallable, Category="Game State")
+	void GameClear();
+
+	void GameStart();
+	void GameEnd();
+	void UpdateHUD();
+	// 탈환지와 관련된 코드 필요
+	// 레드존과 관련된 코드 필요
 };

--- a/Source/Team02/TGameState.h
+++ b/Source/Team02/TGameState.h
@@ -6,8 +6,6 @@
 #include "GameFramework/GameState.h"
 #include "TGameState.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGameTimeUpdate,float,GameTime);
-
 UCLASS()
 class TEAM02_API ATGameState : public AGameState
 {
@@ -16,34 +14,7 @@ class TEAM02_API ATGameState : public AGameState
 public:
 	ATGameState();
 	virtual void BeginPlay() override;
-
-	// 게임 시간 델리게이트
-	UPROPERTY(BlueprintAssignable,Category="Time")
-	FOnGameTimeUpdate OnGameTimeUpdate;
 	
-	//웨이브 관련 변수(웨이브 시간등등)
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Wave")
-	float WaveTime=300.f;
-
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Wave")
-	int32 CurrentWave=1;
-
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Wave")
-	int32 MaxWave=2;
-
-	UPROPERTY(VisibleAnywhere,BlueprintReadOnly,Category="Wave")
-	bool bWaveActive=false;
-
-	//시간 분초로 바꾸는 함수
-	UFUNCTION(BlueprintCallable,Category="Time")
-	FString GetFormattedTime() const;
-
-	
-
-	//타이머
-	FTimerHandle GameTimerHandle; // 게임시간 감소용
-	
-
 	UFUNCTION(BlueprintCallable, Category="Game State")
 	void GameOver();
 	UFUNCTION(BlueprintCallable, Category="Game State")
@@ -52,10 +23,6 @@ public:
 	void GameStart();
 	void GameEnd();
 	void UpdateHUD();
-	void UpdateWaveTime(); //웨이브 타임 함수
-	void WaveTimeUp(); // 웨이브 종료
-	
 	// 탈환지와 관련된 코드 필요
-
 	// 레드존과 관련된 코드 필요
 };

--- a/Source/Team02/TPlayerController.cpp
+++ b/Source/Team02/TPlayerController.cpp
@@ -1,10 +1,9 @@
 ﻿#include "TPlayerController.h"
 #include "GameFramework/Pawn.h"
 #include "TGameState.h"
-#include "Blueprint/UserWidget.h"
 #include "Character/TCharacterBase.h"
-#include "Components/ProgressBar.h"
-#include "Components/TextBlock.h"
+#include "UI/InGame/TUIManager.h"
+
 
 ATPlayerController::ATPlayerController()
 {
@@ -14,64 +13,29 @@ void ATPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
 
-	if (PlayerUIWidgetClass)
+	//점검용 로그
+	UE_LOG(LogTemp, Warning, TEXT("PlayerController BeginPlay called"));
+
+	//UI 매니저 가쟈오기
+	UIManager=GetGameInstance()->GetSubsystem<UTUIManager>();
+	if (UIManager)
 	{
-		// 'UUserWidget*' 타입을 붙이지 않고, 멤버 변수에 대입!
-		PlayerUIWidget = CreateWidget<UUserWidget>(this, PlayerUIWidgetClass);
-		if (PlayerUIWidget)
+		UE_LOG(LogTemp, Warning, TEXT("UIManager found - creating UI"));
+		UIManager->CreatePlayerUI();
+
+		if (ATCharacterBase* PlayerChar=Cast<ATCharacterBase>(GetPawn()))
 		{
-			PlayerUIWidget->AddToViewport();
-		}
-		//시간 델리게이트 관련함수
-		if (ATGameState* GS=GetWorld()->GetGameState<ATGameState>())
-		{
-			//GS->OnGameTimeUpdate.AddDynamic(this,&ATPlayerController::OnGameTimeUpdate);
+			UIManager->SetPlayerCharacter(PlayerChar);
+			UE_LOG(LogTemp, Warning, TEXT("Player character set"));
 		}
 	}
-}
-
-void ATPlayerController::UpdateHPBar()
-{
-	if (!PlayerUIWidget) return;
-
-	// 플레이어 캐릭터 가져오기
-	ATCharacterBase* PlayerCharacter=Cast<ATCharacterBase>(GetPawn());
-	if (!PlayerCharacter) return;
-
-	//ProgessBar 찾기(UI에서는 progessbar 이름이 HPBar임
-	UProgressBar* HPBar=Cast<UProgressBar>(PlayerUIWidget->GetWidgetFromName(TEXT("HPBar")));
-	if (HPBar)
+	else
 	{
-		float HPPercent=PlayerCharacter->GetCurrentHP() / PlayerCharacter->GetMaxHP();
-		HPBar->SetPercent(HPPercent);
+		UE_LOG(LogTemp, Error, TEXT("UIManager NOT found!"));
 	}
 }
 
 void ATPlayerController::SetupInputComponent()
 {
 	Super::SetupInputComponent();
-}
-
-void ATPlayerController::OnGameTimeUpdate(float NewTime)
-{
-	if (!PlayerUIWidget) return;
-
-	if (ATGameState* GS = GetWorld()->GetGameState<ATGameState>())
-	{
-		// 웨이브 시간 업데이트
-		//FString TimeString = GS->GetFormattedTime();
-		UTextBlock* WaveTimeText = Cast<UTextBlock>(PlayerUIWidget->GetWidgetFromName(TEXT("WaveTimeText")));
-		if (WaveTimeText)
-		{
-			//WaveTimeText->SetText(FText::FromString(TimeString));
-		}
-
-		// 웨이브 레벨 업데이트
-		//FString WaveLevelString = FString::Printf(TEXT("Wave %d/%d"), GS->CurrentWave, GS->MaxWave);
-		UTextBlock* WaveLevelText = Cast<UTextBlock>(PlayerUIWidget->GetWidgetFromName(TEXT("WaveLevelText")));
-		if (WaveLevelText)
-		{
-			//WaveLevelText->SetText(FText::FromString(WaveLevelString));
-		}
-	}
 }

--- a/Source/Team02/TPlayerController.cpp
+++ b/Source/Team02/TPlayerController.cpp
@@ -1,10 +1,9 @@
 ﻿#include "TPlayerController.h"
 #include "GameFramework/Pawn.h"
 #include "TGameState.h"
-#include "Blueprint/UserWidget.h"
 #include "Character/TCharacterBase.h"
-#include "Components/ProgressBar.h"
-#include "Components/TextBlock.h"
+#include "UI/InGame/TUIManager.h"
+
 
 ATPlayerController::ATPlayerController()
 {
@@ -14,64 +13,29 @@ void ATPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
 
-	if (PlayerUIWidgetClass)
+	//점검용 로그
+	UE_LOG(LogTemp, Warning, TEXT("PlayerController BeginPlay called"));
+
+	//UI 매니저 가쟈오기
+	UIManager=GetGameInstance()->GetSubsystem<UTUIManager>();
+	if (UIManager)
 	{
-		// 'UUserWidget*' 타입을 붙이지 않고, 멤버 변수에 대입!
-		PlayerUIWidget = CreateWidget<UUserWidget>(this, PlayerUIWidgetClass);
-		if (PlayerUIWidget)
+		UE_LOG(LogTemp, Warning, TEXT("UIManager found - creating UI"));
+		UIManager->CreatePlayerUI();
+
+		if (ATCharacterBase* PlayerChar=Cast<ATCharacterBase>(GetPawn()))
 		{
-			PlayerUIWidget->AddToViewport();
-		}
-		//시간 델리게이트 관련함수
-		if (ATGameState* GS=GetWorld()->GetGameState<ATGameState>())
-		{
-			GS->OnGameTimeUpdate.AddDynamic(this,&ATPlayerController::OnGameTimeUpdate);
+			UIManager->SetPlayerCharacter(PlayerChar);
+			UE_LOG(LogTemp, Warning, TEXT("Player character set"));
 		}
 	}
-}
-
-void ATPlayerController::UpdateHPBar()
-{
-	if (!PlayerUIWidget) return;
-
-	// 플레이어 캐릭터 가져오기
-	ATCharacterBase* PlayerCharacter=Cast<ATCharacterBase>(GetPawn());
-	if (!PlayerCharacter) return;
-
-	//ProgessBar 찾기(UI에서는 progessbar 이름이 HPBar임
-	UProgressBar* HPBar=Cast<UProgressBar>(PlayerUIWidget->GetWidgetFromName(TEXT("HPBar")));
-	if (HPBar)
+	else
 	{
-		float HPPercent=PlayerCharacter->GetCurrentHP() / PlayerCharacter->GetMaxHP();
-		HPBar->SetPercent(HPPercent);
+		UE_LOG(LogTemp, Error, TEXT("UIManager NOT found!"));
 	}
 }
 
 void ATPlayerController::SetupInputComponent()
 {
 	Super::SetupInputComponent();
-}
-
-void ATPlayerController::OnGameTimeUpdate(float NewTime)
-{
-	if (!PlayerUIWidget) return;
-
-	if (ATGameState* GS = GetWorld()->GetGameState<ATGameState>())
-	{
-		// 웨이브 시간 업데이트
-		FString TimeString = GS->GetFormattedTime();
-		UTextBlock* WaveTimeText = Cast<UTextBlock>(PlayerUIWidget->GetWidgetFromName(TEXT("WaveTimeText")));
-		if (WaveTimeText)
-		{
-			WaveTimeText->SetText(FText::FromString(TimeString));
-		}
-
-		// 웨이브 레벨 업데이트
-		FString WaveLevelString = FString::Printf(TEXT("Wave %d/%d"), GS->CurrentWave, GS->MaxWave);
-		UTextBlock* WaveLevelText = Cast<UTextBlock>(PlayerUIWidget->GetWidgetFromName(TEXT("WaveLevelText")));
-		if (WaveLevelText)
-		{
-			WaveLevelText->SetText(FText::FromString(WaveLevelString));
-		}
-	}
 }

--- a/Source/Team02/TPlayerController.h
+++ b/Source/Team02/TPlayerController.h
@@ -7,33 +7,20 @@
 class UInputMappingContext;
 class UInputAction;
 class ATWeaponBase;
-class UUserWidget;
+class UTUIManager;
 UCLASS()
 class TEAM02_API ATPlayerController : public APlayerController
 {
 	GENERATED_BODY()
 public:
 	ATPlayerController();
-	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UI")
-	TSubclassOf<UUserWidget> PlayerUIWidgetClass;
-
-	// UI 위젯 참조 지정
-	UPROPERTY()
-	class UUserWidget* PlayerUIWidget;
-
-	// HP바 업데이트 함수
-	UFUNCTION(BlueprintCallable,Category="UI")
-	void UpdateHPBar();
-
-	// 웨이브 델리게이트 관련함수
-	UFUNCTION()
-	void OnGameTimeUpdate(float NewTime);
 
 protected:
 	virtual void BeginPlay() override;
 	virtual void SetupInputComponent() override;
 
-	//UI 업데이트용 타이머
-	FTimerHandle UIUpdateTimerHandle;
+private:
+	// UI 매니저 참조 관련
+	UPROPERTY()
+	TObjectPtr<UTUIManager> UIManager;
 };

--- a/Source/Team02/UI/InGame/TBossHealthBarComponent.cpp
+++ b/Source/Team02/UI/InGame/TBossHealthBarComponent.cpp
@@ -1,0 +1,102 @@
+#include "TBossHealthBarComponent.h"
+#include "TBossHealthBarWidget.h"
+#include "Character/TCharacterBase.h"
+#include "Components/WidgetComponent.h"
+#include "Blueprint/UserWidget.h"
+
+UTBossHealthBarComponent::UTBossHealthBarComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+
+	// create Widget Component
+	BossHealthBarWidgetComponent=CreateDefaultSubobject<UWidgetComponent>(TEXT("BossHealthBarWidget"));
+
+	//set initialize value
+	LastKnownCurrentHP=-1.0f;
+	LastKnownMaxHP=-1.0f;
+	
+}
+
+void UTBossHealthBarComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	OwnerCharacter=Cast<ATCharacterBase>(GetOwner());
+
+	// attach widgetcomponent for character mesh
+	if (OwnerCharacter && BossHealthBarWidgetComponent)
+	{
+		BossHealthBarWidgetComponent->AttachToComponent(
+			OwnerCharacter->GetMesh(),
+			FAttachmentTransformRules::KeepRelativeTransform);
+
+		UE_LOG(LogTemp,Warning,TEXT("Boss Widget attached to Char Mesh"));
+	}
+
+	InitializeBossHealthBar();
+	
+}
+
+
+void UTBossHealthBarComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	// 체력 변화 감지 및 업데이트
+	if (OwnerCharacter)
+	{
+		float CurrentHP=OwnerCharacter->GetCurrentHP();
+		float MaxHP=OwnerCharacter->GetMaxHP();
+
+		// update when boss health is change
+		if (CurrentHP != LastKnownCurrentHP || MaxHP != LastKnownMaxHP)
+		{
+			if (UTBossHealthBarWidget* BossWidget =Cast<UTBossHealthBarWidget>(BossHealthBarWidgetComponent->GetUserWidgetObject()))
+			{
+				BossWidget->UpdateHealthBar(CurrentHP,MaxHP);
+			}
+			LastKnownCurrentHP=CurrentHP;
+			LastKnownMaxHP=MaxHP;
+		}
+	}
+	// 보스 체력바 측면 이상하게보이는거랑 글자뒤집히는거 방지
+	if (BossHealthBarWidgetComponent)
+	{
+		APlayerController* PC=GetWorld()->GetFirstPlayerController();
+		if (PC && PC->PlayerCameraManager)
+		{
+			FVector CameraLocation=PC->PlayerCameraManager->GetCameraLocation();
+			FVector WidgetLocation=BossHealthBarWidgetComponent->GetComponentLocation();
+
+			//Y축만 회전
+			FVector Direction=CameraLocation-WidgetLocation;
+			Direction.Z=0.0f;
+
+			FRotator LookRotation=Direction.Rotation();
+			BossHealthBarWidgetComponent->SetWorldRotation(LookRotation);
+		}
+	}
+}
+
+void UTBossHealthBarComponent::InitializeBossHealthBar()
+{
+	if (BossHealthBarWidgetComponent && BossHealthBarWidgetClass)
+	{
+		BossHealthBarWidgetComponent->SetWidgetClass(BossHealthBarWidgetClass);
+		BossHealthBarWidgetComponent->SetWidgetSpace(EWidgetSpace::World);
+
+		BossHealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f,0.0f,225.0f));
+
+		// 보스 체력바 월드 배치크기
+		BossHealthBarWidgetComponent->SetDrawSize(FVector2D(800.0f,300.0f));
+		BossHealthBarWidgetComponent->SetWorldScale3D(FVector(0.3f, 0.3f, 0.3f));
+		BossHealthBarWidgetComponent->SetDrawAtDesiredSize(false);
+
+		// 체력바가 플레이어 카메라 바라보게끔
+		BossHealthBarWidgetComponent->SetTwoSided(true);
+
+		//오류 점검용 로그
+		UE_LOG(LogTemp,Warning,TEXT("Boss Widget setup!"));
+		
+	}
+}

--- a/Source/Team02/UI/InGame/TBossHealthBarComponent.cpp
+++ b/Source/Team02/UI/InGame/TBossHealthBarComponent.cpp
@@ -85,7 +85,7 @@ void UTBossHealthBarComponent::InitializeBossHealthBar()
 		BossHealthBarWidgetComponent->SetWidgetClass(BossHealthBarWidgetClass);
 		BossHealthBarWidgetComponent->SetWidgetSpace(EWidgetSpace::World);
 
-		BossHealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f,0.0f,225.0f));
+		BossHealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f,0.0f,190.0f));
 
 		// 보스 체력바 월드 배치크기
 		BossHealthBarWidgetComponent->SetDrawSize(FVector2D(800.0f,300.0f));

--- a/Source/Team02/UI/InGame/TBossHealthBarComponent.h
+++ b/Source/Team02/UI/InGame/TBossHealthBarComponent.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Components/WidgetComponent.h"
+#include "TBossHealthBarComponent.generated.h"
+
+class UTBossHealthBarWidget;
+class ATCharacterBase;
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class TEAM02_API UTBossHealthBarComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	UTBossHealthBarComponent();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+	// health bar initialize
+	UFUNCTION(BlueprintCallable)
+	void InitializeBossHealthBar();
+
+protected:
+	//widget component (world space ui)
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	TObjectPtr<UWidgetComponent> BossHealthBarWidgetComponent;
+
+	// widget class reference
+	UPROPERTY(EditAnywhere,BlueprintReadonly)
+	TSubclassOf<UTBossHealthBarWidget> BossHealthBarWidgetClass;
+
+	//체력값 캐시
+	float LastKnownCurrentHP;
+	float LastKnownMaxHP;
+
+	//owner 캐릭터 참조
+	UPROPERTY()
+	TObjectPtr<ATCharacterBase> OwnerCharacter;
+	
+};

--- a/Source/Team02/UI/InGame/TBossHealthBarWidget.cpp
+++ b/Source/Team02/UI/InGame/TBossHealthBarWidget.cpp
@@ -1,0 +1,39 @@
+#include "TBossHealthBarWidget.h"
+#include "Components/ProgressBar.h"
+#include "Components/TextBlock.h"
+
+void UTBossHealthBarWidget::UpdateHealthBar(float CurrentHP, float MaxHP)
+{
+	if (BossHealthBar && HealthText)
+	{
+		//caculate hp percent
+		float HealthPercent=(MaxHP>0.0f) ? (CurrentHP/MaxHP) : 0.0f;
+
+		// progress bar update
+		BossHealthBar->SetPercent(HealthPercent);
+
+		// Hp text update( use percent)
+		FString HealthString=FString::Printf(TEXT("%.0f%%"),HealthPercent * 100.0f);
+		HealthText->SetText(FText::FromString(HealthString));
+		
+	}
+}
+
+void UTBossHealthBarWidget::SetBossName(const FString& Name)
+{
+	if (BossName)
+	{
+		BossName->SetText(FText::FromString(Name));
+	}
+}
+
+void UTBossHealthBarWidget::ShowHealthBar()
+{
+	SetVisibility(ESlateVisibility::Visible);
+}
+
+void UTBossHealthBarWidget::HideHealthBar()
+{
+	SetVisibility(ESlateVisibility::Hidden);
+}
+

--- a/Source/Team02/UI/InGame/TBossHealthBarWidget.h
+++ b/Source/Team02/UI/InGame/TBossHealthBarWidget.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Components/ProgressBar.h"
+#include "Components/TextBlock.h"
+#include "TBossHealthBarWidget.generated.h"
+
+
+UCLASS()
+class TEAM02_API UTBossHealthBarWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	// set hp update function
+	UFUNCTION(BlueprintCallable)
+	void UpdateHealthBar(float CurrentHP,float MaxHP);
+
+	//set boss name
+	UFUNCTION(BlueprintCallable)
+	void SetBossName(const FString& Name);
+
+	//show or hide widget
+	UFUNCTION(BlueprintCallable)
+	void ShowHealthBar();
+	UFUNCTION(BlueprintCallable)
+	void HideHealthBar();
+
+protected:
+	// widget binding
+
+	UPROPERTY(meta=(BindWidget))
+	TObjectPtr<UProgressBar> BossHealthBar;
+	UPROPERTY(meta=(BindWidget))
+	TObjectPtr<UTextBlock> BossName;
+	UPROPERTY(meta=(BindWidget))
+	TObjectPtr<UTextBlock> HealthText;
+
+
+
+	
+};

--- a/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
@@ -92,7 +92,7 @@ void UTMonsterHealthBarComponent::InitializeHealthBar()
 		HealthBarWidgetComponent->SetDrawSize(FVector2D(500.0f, 200.0f));  // 사이즈 설정
 		HealthBarWidgetComponent->SetWorldScale3D(FVector(0.2f, 0.2f, 0.2f)); // 스케일 조정
 		HealthBarWidgetComponent->SetDrawAtDesiredSize(false);
-		HealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f, 0.0f, 205.0f)); // UI위치
+		HealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f, 0.0f, 195.0f)); // UI위치
 		
 
 		// 항상 카메라를 바라보도록

--- a/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
@@ -1,0 +1,103 @@
+#include "TMonsterHealthBarComponent.h"
+#include "TMonsterHealthBarWidget.h"
+#include "Character/TCharacterBase.h"
+#include "Components/WidgetComponent.h"
+#include "Blueprint/UserWidget.h"
+
+
+
+UTMonsterHealthBarComponent::UTMonsterHealthBarComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+	// create widget component
+	HealthBarWidgetComponent=CreateDefaultSubobject<UWidgetComponent>(TEXT("HealthBarWidget"));
+	
+	//initialize values
+	LastKnownCurrentHP=-1.0f;
+	LastKnownMaxHP=-1.0f;
+	
+}
+
+void UTMonsterHealthBarComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	OwnerCharacter = Cast<ATCharacterBase>(GetOwner());
+    
+	// 핵심: WidgetComponent를 캐릭터의 Mesh에 직접 어태치
+	if (OwnerCharacter && HealthBarWidgetComponent)
+	{
+		HealthBarWidgetComponent->AttachToComponent(
+			OwnerCharacter->GetMesh(),  // RootComponent 대신 Mesh 사용
+			FAttachmentTransformRules::KeepRelativeTransform
+		);
+		
+		UE_LOG(LogTemp, Warning, TEXT("Widget attached to character mesh"));
+	}
+    
+	InitializeHealthBar();
+	
+}
+
+void UTMonsterHealthBarComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	//체력변화 감지 및 업데이트
+	if (OwnerCharacter)
+	{
+		float CurrentHP=OwnerCharacter->GetCurrentHP();
+		float MaxHP=OwnerCharacter->GetMaxHP();
+
+		// 체력 변할떄만 업데이트
+		if (CurrentHP != LastKnownCurrentHP || MaxHP != LastKnownMaxHP)
+		{
+			if (UTMonsterHealthBarWidget* HealthWidget=Cast<UTMonsterHealthBarWidget>(HealthBarWidgetComponent->GetUserWidgetObject()))
+			{
+				HealthWidget->UpdateHealthBar(CurrentHP,MaxHP);
+			}
+			LastKnownCurrentHP=CurrentHP;
+			LastKnownMaxHP=MaxHP;
+				
+		}
+	}
+	// 체력바 뒤집히는거 방지 + y축만 회전
+	if (HealthBarWidgetComponent)
+	{
+		APlayerController* PC=GetWorld()->GetFirstPlayerController();
+		if (PC && PC->PlayerCameraManager)
+		{
+			FVector CameraLocation=PC->PlayerCameraManager->GetCameraLocation();
+			FVector WidgetLocation= HealthBarWidgetComponent->GetComponentLocation();
+
+			//y축만 회전
+			FVector Direction=CameraLocation-WidgetLocation;
+			Direction.Z=0.0f;
+
+			FRotator LookRotation=Direction.Rotation();
+			HealthBarWidgetComponent->SetWorldRotation(LookRotation);
+		}
+	}
+
+
+	
+}
+
+void UTMonsterHealthBarComponent::InitializeHealthBar()
+{
+	if (HealthBarWidgetComponent && HealthBarWidgetClass)
+	{
+		HealthBarWidgetComponent->SetWidgetClass(HealthBarWidgetClass);
+		HealthBarWidgetComponent->SetWidgetSpace(EWidgetSpace::World);
+		HealthBarWidgetComponent->SetDrawSize(FVector2D(500.0f, 200.0f));  // 사이즈 설정
+		HealthBarWidgetComponent->SetWorldScale3D(FVector(0.2f, 0.2f, 0.2f)); // 스케일 조정
+		HealthBarWidgetComponent->SetDrawAtDesiredSize(false);
+		HealthBarWidgetComponent->SetRelativeLocation(FVector(0.0f, 0.0f, 205.0f)); // UI위치
+		
+
+		// 항상 카메라를 바라보도록
+		HealthBarWidgetComponent->SetTwoSided(true);
+		// 오류 점검 로그
+		UE_LOG(LogTemp, Warning, TEXT("Widget setup complete"));
+	}
+}

--- a/Source/Team02/UI/InGame/TMonsterHealthBarComponent.h
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarComponent.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Components/WidgetComponent.h"
+#include "TMonsterHealthBarComponent.generated.h"
+
+class UTMonsterHealthBarWidget;
+class ATCharacterBase;
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class TEAM02_API UTMonsterHealthBarComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	UTMonsterHealthBarComponent();
+
+protected:
+	virtual void BeginPlay() override;
+
+public:	
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+	// 체력바 초기화
+	UFUNCTION(BlueprintCallable)
+	void InitializeHealthBar();
+
+protected:
+	// widget component(world space UI)
+	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
+	TObjectPtr<UWidgetComponent> HealthBarWidgetComponent;
+
+	//widget class reference
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	TSubclassOf<UTMonsterHealthBarWidget> HealthBarWidgetClass;
+
+	// 체력값
+	float LastKnownCurrentHP;
+	float LastKnownMaxHP;
+
+	// 오너 캐릭터 레퍼런스
+	UPROPERTY()
+	TObjectPtr<ATCharacterBase> OwnerCharacter;
+		
+};

--- a/Source/Team02/UI/InGame/TMonsterHealthBarWidget.cpp
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarWidget.cpp
@@ -12,8 +12,8 @@ void UTMonsterHealthBarWidget::UpdateHealthBar(float CurrentHP,float MaxHP)
 		// progress bar update
 		HealthProgressBar->SetPercent(HealthPercent);
 		
-		// hp text update (ex: 70/100)
-		FString HealthString=FString::Printf(TEXT("%.0f/%.0f"),CurrentHP,MaxHP);
+		// hp text update (ex: 70%/100%)
+		FString HealthString=FString::Printf(TEXT("%.0f%%"),HealthPercent * 100.0f);
 		HealthText->SetText(FText::FromString(HealthString));
 	}
 }

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -1,0 +1,36 @@
+#include "TPlayerUIWidget.h"
+#include "Components/ProgressBar.h"
+#include "Components/TextBlock.h"
+
+void UTPlayerUIWidget::UpdateHPBar(float CurrentHP, float MaxHP)
+{
+	if (HPBar)
+	{
+		float HPPercent=(MaxHP>0.0f) ? (CurrentHP/MaxHP) : 0.0f;
+		HPBar->SetPercent(HPPercent);
+	}
+	if (HPText)
+	{
+		float HPPercent=(MaxHP>0.0f) ? (CurrentHP/ MaxHP) : 0.0f;
+		FString HPString=FString::Printf(TEXT("%.0f%%"),HPPercent * 100.0f);
+		HPText->SetText(FText::FromString(HPString));
+	}
+}
+
+void UTPlayerUIWidget::UpdateAmmoInfo(int32 CurrentAmmo, int32 MaxAmmo)
+{
+	if (AmmoText)
+	{
+		FString AmmoString=FString::Printf(TEXT("%d/%d"),CurrentAmmo,MaxAmmo);
+		AmmoText->SetText(FText::FromString(AmmoString));
+	}
+}
+
+void UTPlayerUIWidget::UpdateWaveTime(const FString& TimeString)
+{
+	if (WaveTimeText)
+	{
+		WaveTimeText->SetText(FText::FromString(TimeString));
+	}
+}
+

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -34,3 +34,95 @@ void UTPlayerUIWidget::UpdateWaveTime(const FString& TimeString)
 	}
 }
 
+void UTPlayerUIWidget::ShowCaptureUI(const FString& AreaName)
+{
+	// 거점 UI 요소들 표시
+	if (CaptureBar)
+	{
+		CaptureBar->SetVisibility(ESlateVisibility::Visible);
+		CaptureBar->SetPercent(0.0f); // 초기 진행도 0%
+	}
+
+	if (CapturePercent)
+	{
+		CapturePercent->SetVisibility(ESlateVisibility::Visible);
+		CapturePercent->SetText(FText::FromString(TEXT("0%")));
+	}
+
+	if (CaptureLabel)
+	{
+		CaptureLabel->SetVisibility(ESlateVisibility::Visible);
+		
+		// 메시지를 깔끔하게 표시
+		FString CaptureMessage=TEXT("Capturing area...");
+		CaptureLabel->SetText(FText::FromString(CaptureMessage));
+
+		//테스트 로그
+		UE_LOG(LogTemp,Warning,TEXT("CaptureLabel set to Visible!!"));
+	}
+	
+	
+}
+
+void UTPlayerUIWidget::HideCaptureUI()
+{
+	//거점 UI 요소들 숨김
+	if (CaptureBar)
+	{
+		CaptureBar->SetVisibility(ESlateVisibility::Hidden);
+	}
+
+	if (CapturePercent)
+	{
+		CapturePercent->SetVisibility(ESlateVisibility::Hidden);
+	}
+
+	if (CaptureLabel)
+	{
+		CaptureLabel->SetVisibility(ESlateVisibility::Hidden);
+	}
+
+	//테스트 로그
+	UE_LOG(LogTemp,Warning,TEXT("Capture UI Hidden"));
+}
+
+void UTPlayerUIWidget::UpdateCaptureProgress(float Progress)
+{
+	// 진행도 업데이트
+	Progress=FMath::Clamp(Progress,0.0f,1.0f);
+
+	if (CaptureBar)
+	{
+		CaptureBar->SetPercent(Progress);
+	}
+
+	if (CapturePercent)
+	{
+		//퍼센트로 표시
+		FString ProgressString=FString::Printf(TEXT("%.0f%%"),Progress * 100.0f);
+		CapturePercent->SetText(FText::FromString(ProgressString));
+	}
+	// 점령 완료시 메시지 변경
+	if (CaptureLabel && Progress>=1.0f)
+	{
+		CaptureLabel->SetText(FText::FromString(TEXT("Captured!")));
+	}
+}
+
+bool UTPlayerUIWidget::IsCaptureUIVisible() const
+{
+	if (CaptureBar)
+	{
+		return CaptureBar->GetVisibility()==ESlateVisibility::Visible;
+	}
+	return false;
+}
+
+void UTPlayerUIWidget::UpdateMissionObjective(const FString& ObjectiveText)
+{
+	if (ObjectText)
+	{
+		ObjectText->SetText(FText::FromString(ObjectiveText));
+		UE_LOG(LogTemp,Warning,TEXT("Mission updated: %s"), *ObjectiveText);
+	}
+}

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.h
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "Components/ProgressBar.h"
+#include "Components/TextBlock.h"
+#include "TPlayerUIWidget.generated.h"
+
+UCLASS()
+class TEAM02_API UTPlayerUIWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable)
+	void UpdateHPBar(float CurrentHP, float MaxHP);
+    
+	UFUNCTION(BlueprintCallable)
+	void UpdateAmmoInfo(int32 CurrentAmmo, int32 MaxAmmo);
+    
+	UFUNCTION(BlueprintCallable)
+	void UpdateWaveTime(const FString& TimeString);
+
+protected:
+	// ⭐ 각 이름이 한 번씩만 나와야 함
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UProgressBar> HPBar;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> HPText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> AmmoText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> WaveTimeText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> WaveComeText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> ObjectText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> KillCountText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UProgressBar> CaptureBar;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> CapturePercent;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> CaptureLabel;
+};

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.h
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.h
@@ -21,6 +21,27 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void UpdateWaveTime(const FString& TimeString);
 
+	//거점 점령 관련 함수
+
+	UFUNCTION(BlueprintCallable)
+	void ShowCaptureUI(const FString& AreaName);
+	
+	UFUNCTION(BlueprintCallable)
+	void HideCaptureUI();
+	
+	UFUNCTION(BlueprintCallable)
+	void UpdateCaptureProgress(float Progress);
+
+	//거점 UI 표시 상태 확인 함수 추가
+	UFUNCTION(BlueprintCallable)
+	bool IsCaptureUIVisible() const;
+
+	// 임무 관련 함수 추가
+	UFUNCTION(BlueprintCallable)
+	void UpdateMissionObjective(const FString& ObjectiveText);
+
+	
+
 protected:
 	// ⭐ 각 이름이 한 번씩만 나와야 함
 	UPROPERTY(meta = (BindWidget))
@@ -36,7 +57,7 @@ protected:
 	TObjectPtr<UTextBlock> WaveTimeText;
 
 	UPROPERTY(meta = (BindWidget))
-	TObjectPtr<UTextBlock> WaveComeText;
+	TObjectPtr<UTextBlock> WaveAlarmText;
 
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<UTextBlock> ObjectText;

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -1,0 +1,150 @@
+#include "TUIManager.h"
+#include "TPlayerUIWidget.h"
+#include "Character/TCharacterBase.h"
+#include "Item/TWeaponBase.h"
+#include "Character/TPlayerCharacter.h"
+#include "Blueprint/UserWidget.h"
+#include "Engine/World.h"
+
+void UTUIManager::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	//테스트 로그
+	UE_LOG(LogTemp,Warning,TEXT("UIManager Initialized!!"));
+}
+
+void UTUIManager::CreatePlayerUI()
+{
+	// ⭐ PlayerUIWidgetClass가 설정되지 않았으면 직접 로드
+	if (!PlayerUIWidgetClass)
+	{
+		// Team02/UI/InGame/WBP_PlayerUI 경로로 로드
+		PlayerUIWidgetClass = LoadClass<UTPlayerUIWidget>(nullptr, TEXT("/Game/Team02/UI/InGame/WBP_PlayerUI.WBP_PlayerUI_C"));
+        
+		if (!PlayerUIWidgetClass)
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to load WBP_PlayerUI! Check the path."));
+			return;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("WBP_PlayerUI loaded successfully!"));
+		}
+	}
+
+	if (GetWorld())
+	{
+		PlayerUIWidget = CreateWidget<UTPlayerUIWidget>(GetWorld(), PlayerUIWidgetClass);
+		if (PlayerUIWidget)
+		{
+			PlayerUIWidget->AddToViewport();
+			UE_LOG(LogTemp, Warning, TEXT("Player UI Created Successfully!"));
+
+			// 웨이브 시스템 시작
+			bWaveActive = true;
+			GetWorld()->GetTimerManager().SetTimer(
+				WaveTimerHandle,
+				this,
+				&UTUIManager::UpdateWaveTime,
+				1.0f,
+				true);
+
+			// UI 업데이트 타이머
+			GetWorld()->GetTimerManager().SetTimer(
+				UIUpdateTimerHandle,
+				this,
+				&UTUIManager::UpdateAllUI,
+				0.1f,
+				true);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to create PlayerUIWidget!"));
+		}
+	}
+}
+
+void UTUIManager::SetPlayerCharacter(ATCharacterBase* PlayerChar)
+{
+	PlayerCharacter=PlayerChar;
+
+	// find player's current weapon
+	if (ATPlayerCharacter*PC=Cast<ATPlayerCharacter>(PlayerChar))
+	{
+		CurrentWeapon=PC->CurrentWeapon;
+	}
+}
+
+void UTUIManager::UpdatePlayerHP()
+{
+	if (PlayerUIWidget && PlayerCharacter)
+	{
+		PlayerUIWidget->UpdateHPBar(PlayerCharacter->GetCurrentHP(),PlayerCharacter->GetMaxHP());
+	}
+}
+
+void UTUIManager::UpdatePlayerAmmo()
+{
+	if (PlayerUIWidget && CurrentWeapon)
+	{
+		PlayerUIWidget->UpdateAmmoInfo(CurrentWeapon->CurrentAmmo,CurrentWeapon->MaxAmmo);
+	}
+}
+
+void UTUIManager::UpdateWaveInfo(const FString& TimeString,int32 InCurrentWave,int32 InMaxWave)
+{
+	if (PlayerUIWidget)
+	{
+		PlayerUIWidget->UpdateWaveTime(TimeString);
+	}
+}
+
+void UTUIManager::UpdateWaveTime()
+{
+	if (!bWaveActive) return;
+
+	WaveTime-=1.0f;
+	
+	if (WaveTime<=0.0f)
+	{
+		bWaveActive=false;
+	}
+}
+
+FString UTUIManager::GetFormattedTime() const
+{
+	int32 Minutes = FMath::FloorToInt(WaveTime / 60.0f);
+	int32 Seconds = FMath::FloorToInt(WaveTime) % 60;
+	return FString::Printf(TEXT("%02d:%02d"), Minutes, Seconds);
+}
+
+
+
+void UTUIManager::UpdateAllUI()
+{
+	// update player weapon
+	if (ATPlayerCharacter* PC=Cast<ATPlayerCharacter>(PlayerCharacter))
+	{
+		CurrentWeapon=PC->CurrentWeapon;
+	}
+	// update all player ui
+	UpdatePlayerHP();
+	UpdatePlayerAmmo();
+
+	// 자체 웨이브 정보 업데이트
+	if (PlayerUIWidget)
+	{
+		FString TimeString = GetFormattedTime();
+		PlayerUIWidget->UpdateWaveTime(TimeString);
+	}
+}
+void UTUIManager::Deinitialize()
+{
+	//타이머 세팅
+	if (GetWorld())
+	{
+		GetWorld()->GetTimerManager().ClearTimer(UIUpdateTimerHandle);
+		GetWorld()->GetTimerManager().ClearTimer(WaveTimerHandle);
+	}
+	Super::Deinitialize();
+}

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "TPlayerUIWidget.h"
+#include "TUIManager.generated.h"
+
+class ATCharacterBase;
+class ATWeaponBase;
+
+UCLASS()
+class TEAM02_API UTUIManager : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	// initializce Subsystem
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	//create UI
+	UFUNCTION(BlueprintCallable)
+	void CreatePlayerUI();
+
+	// update ui functions
+	UFUNCTION(BlueprintCallable)
+	void UpdatePlayerHP();
+	
+	UFUNCTION(BlueprintCallable)
+	void UpdatePlayerAmmo();
+
+	UFUNCTION(BlueprintCallable)
+	void UpdateWaveInfo(const FString& TimeString,int32 InCurrentWave,int32 InMaxWave);
+
+	// Player references
+	UFUNCTION(BlueprintCallable)
+	void SetPlayerCharacter(ATCharacterBase* PlayerChar);
+
+protected:
+	// UI widget class
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	TSubclassOf<UTPlayerUIWidget> PlayerUIWidgetClass;
+
+	//UI widget instance
+	UPROPERTY()
+	TObjectPtr<UTPlayerUIWidget> PlayerUIWidget;
+
+	//Player reference
+	UPROPERTY()
+	TObjectPtr<ATCharacterBase> PlayerCharacter;
+
+	// current weapon reference
+	UPROPERTY()
+	TObjectPtr<ATWeaponBase> CurrentWeapon;
+
+	// Timer
+	FTimerHandle UIUpdateTimerHandle;
+
+	// Wave Functions
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	float WaveTime=300.0f;
+
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	int32 CurrentWave=1;
+
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	int32 MaxWave=2;
+
+	UPROPERTY(EditAnywhere,BlueprintReadOnly)
+	bool bWaveActive=false;
+
+	//Wave Timer
+	FTimerHandle WaveTimerHandle;
+
+	// update Wavetime
+	void UpdateWaveTime();
+
+	//시간 분초 포맷
+	FString GetFormattedTime() const;
+	
+	// regularly ui update
+	void UpdateAllUI();
+	
+	
+};

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -4,7 +4,9 @@
 #include "UObject/NoExportTypes.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "TPlayerUIWidget.h"
+#include "Area/TCapturePoint.h"
 #include "TUIManager.generated.h"
+
 
 class ATCharacterBase;
 class ATWeaponBase;
@@ -36,6 +38,35 @@ public:
 	// Player references
 	UFUNCTION(BlueprintCallable)
 	void SetPlayerCharacter(ATCharacterBase* PlayerChar);
+
+	// 거점 관련 함수
+	UFUNCTION(BlueprintCallable)
+	void ShowCaptureUI(const FString& AreaName);
+
+	UFUNCTION(BlueprintCallable)
+	void HideCaptureUI();
+
+	UFUNCTION(BlueprintCallable)
+	void UpdateCaptureProgress(float Progress);
+
+	// 거점 연동 함수
+	UFUNCTION(BlueprintCallable)
+	void RegisterCapturePoint(class ATCapturePoint* CapturePoint);
+
+	// 거점 자동 검색 함수
+	UFUNCTION(BlueprintCallable)
+	void FindAndRegisterCapturePoints();
+
+	// 임무 관련 함수
+	UFUNCTION(BLueprintCallable)
+	void SetMissionObjective(const FString& NewObjective);
+	
+	UFUNCTION(BlueprintCallable)
+	void UpdateMissionProgress();
+
+	UFUNCTION(BlueprintCallable)
+	void IncrementMonsterKill();
+	
 
 protected:
 	// UI widget class
@@ -70,17 +101,67 @@ protected:
 	UPROPERTY(EditAnywhere,BlueprintReadOnly)
 	bool bWaveActive=false;
 
+	// 게임 플로우 반영 변수 ( 웨이브 시작> 몬스터 처치 (웨이브클리어) >거점 점령 >보스전 순서 )
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bWaveCompleted = false;  // 웨이브 완료 여부
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bCapturePhase = false;   // 점령 페이즈 여부
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bCaptureCompleted = false; // 점령완료
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bWeaponUnlocked=false;  // 무기 해금
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bBossPhase=false; // 보스전 페이즈
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	int32 RemainingMonsters = 5;  // 남은 몬스터 수 (가상)
+
 	//Wave Timer
-	FTimerHandle WaveTimerHandle;
+	FTimerHandle WaveTimerHandle; 
 
 	// update Wavetime
 	void UpdateWaveTime();
 
 	//시간 분초 포맷
 	FString GetFormattedTime() const;
+
+	// 현재 활성 거점
+	UPROPERTY()
+	TObjectPtr<class ATCapturePoint> CurrentCapturePoint;
+
+	//거점 이름
+	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	FString CapturePointName=TEXT("Control Point");
+
+	//임무 관련 변수들
+	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	FString CurrentMissionObjective=TEXT("Kill Monsters"); // 임무 목표 표시
+	
+	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	int32 MonsterKillCount=0; // KillCountText UI 업데이트용
+	
+	// 임무 상태 플래그
+	//거점 감지용
+	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	bool bNearCapturePoint=false; 
+
+
 	
 	// regularly ui update
 	void UpdateAllUI();
-	
+
+private:
+	// 임무 상태 업데이트
+	void UpdateMissionState();
 	
 };
+
+//TCapturePoint의 Tick() 함수에서 이미 점령률이 계산되고 있으니
+//UIManager가 CapturePoint를 감시
+//플레이어 진입/이탈 감지
+//점령률 변화 자동 감지
+//웨이브 를 다 마치고 점령 100% 채우면 점령이 되는 방식

--- a/Team02.uproject
+++ b/Team02.uproject
@@ -11,7 +11,8 @@
 			"AdditionalDependencies": [
 				"AIModule",
 				"Engine",
-				"UMG"
+				"UMG",
+				"CoreUObject"
 			]
 		}
 	],


### PR DESCRIPTION
UIManager추가, 전체적인 UI담당 파트 클래스 생성
잡몹,보스몬스터 체력바 관련 컴포넌트 추가
PlayerController에서는 UI구현 부분 제외하고는 삭제,GameState는 기존코드 삭제 완료
기존 테스트용 웨이브코드는 UIManager에서 임시적으로 담당

거점관련함수, 거점 UI요소들 추가,
CaputrePoint 블루프린트 테스트용으로 생성해서 추가
플레이그라운드 테스트떄문에 용도변경
