### PR TITLE
보스 이벤트 메커니즘을 추가하고 미션 UI를 개선함.

### DIFF
--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ee6178fd05063853a98aeb787bd063fcd3fc5e58fe1d611e644dba2b05e3c4a
-size 49510
+oid sha256:b1b8f444cb98d9660747c46ecfc38f42cf3e01f62913112c5aec3b7fc4b04c1c
+size 49505

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.h
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.h
@@ -47,6 +47,13 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	void HideEnemyIncomingAlarm();
+
+	//타이핑 애니메이션 함수
+	UFUNCTION(BLueprintCallable)
+	void StartTypingAnimation(const FString& FullText);
+
+	UFUNCTION(BlueprintCallable)
+	void StartFlashingAndChangeText(const FString& NewText);
 	
 
 
@@ -78,4 +85,30 @@ protected:
 
 	UPROPERTY(meta = (BindWidget))
 	TObjectPtr<UTextBlock> CaptureLabel;
+
+	//타이밍 애니메이션 변수
+	UPROPERTY()
+	FString TargetText; // 최종 표시 텍스트
+
+	UPROPERTY()
+	FString CurrentDisplayText; // 현재 표시중인 텍스트
+
+	UPROPERTY()
+	int32 CurrentCharIndex; // 현재 글자 인덱스
+
+	UPROPERTY()
+	bool bIsTyping; // 타이핑 중인지 확인
+
+	FTimerHandle TypingTimerHandle; // 타이핑 타이머
+	FTimerHandle FlashTimerHandle; 
+
+private:
+	// 타이핑 애니메이션 함수
+	void UpdateTypingText();
+	void FlashText();
+	void StopFlashing();
+
+	// 진짜 미션인지 확인 하는 함수
+	bool IsRealMissionChange(const FString& OldText,const FString& NewText);
+	
 };

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -340,6 +340,13 @@ void UTUIManager::UpdateMonsterStatus()
 		//게임 완료 처리
 		bBossPhase=false;
 		SetMissionObjective(TEXT("Victory! Boss Defeated!"));
+
+		// 승리 이벤트 발생!
+		OnVictoryEvent.Broadcast();
+		UE_LOG(LogTemp,Warning,TEXT("Victory event broadcasted!!"));
+
+
+		
 	}
 
 	

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -7,6 +7,9 @@
 #include "Area/TCapturePoint.h"
 #include "TUIManager.generated.h"
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnVictoryDelegate);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnGameOverDelegate);
+
 class ATCharacterBase;
 class ATWeaponBase;
 class ATAIBossMonster;
@@ -17,6 +20,14 @@ class TEAM02_API UTUIManager : public UGameInstanceSubsystem
 	GENERATED_BODY()
 
 public:
+	// OutGameUI 개발자와 협업 델리게이트 코드
+	UPROPERTY(BLueprintAssignable)
+	FOnVictoryDelegate OnVictoryEvent;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnGameOverDelegate OnGameOverEvent;
+	
+	
 	// initializce Subsystem
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -9,6 +9,7 @@
 
 class ATCharacterBase;
 class ATWeaponBase;
+class ATAIBossMonster;
 
 UCLASS()
 class TEAM02_API UTUIManager : public UGameInstanceSubsystem
@@ -146,9 +147,17 @@ protected:
 	UPROPERTY()
 	TArray<class ATNonPlayerCharacter*> TrackedMonsters;
 
-	// 이전 프레임 몬스터 수 (변화 감지용)
+	// 이전 프레임 몬스터,보스 수(변화 감지용)
 	UPROPERTY()
 	int32 LastFrameMonsterCount=0;
+
+	UPROPERTY()
+	int32 LastFrameBossCount=0;
+	
+
+	// 보스 추적용
+	UPROPERTY()
+	TArray<class ATAIBossMonster*> TrackedBosses;
 	
 	// regularly ui update
 	void UpdateAllUI();
@@ -165,7 +174,9 @@ private:
 
 	//스포너에서 웨이브 정보 가져오기
 	void UpdateWaveInfoFromSpawners();
-	
+
+	//보스 찾기 함수
+	void FindAllBossesInWorld();
 };
 
 //TCapturePoint의 Tick() 함수에서 이미 점령률이 계산되고 있으니


### PR DESCRIPTION
이 풀 리퀘스트는 보스 이벤트와 관련된 새로운 메커니즘과 UI 개선을 도입합니다.


보스 미션 완료 시 승리 이벤트를 브로드캐스팅하고 로그를 기록하는 기능을 구현하였습니다.

보스 몬스터를 감지하고 추적하는 로직을 추가하였습니다.

보스 처치 감지 기능을 포함하였습니다.

미션 텍스트에 깜빡임, 타자 효과 등 애니메이션 효과를 추가하여 개선하였습니다.

테스트를 위해 플레이그라운드 맵과 UI 에셋을 업데이트하였습니다.