### PR TITLE
Fix 게임 리스폰시 플레이어 인게임으로 입력 수정

### DIFF
--- a/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06b26db9a2ca19101798a7d49c4a504fef916dd54cfb92e42489e293918f3a2e
-size 60999
+oid sha256:1b0e422a00b2c09f0c62cd13b29a9f5f8d69224e983ad20ee52bbfe2f52819d6
+size 63164


### PR DESCRIPTION
WBP_GameOverMenu 수정 중 블루프린트 Respawn 버튼 눌렀을 때 플레이어가 리스폰이 초기 시작지점으로 가도록 설정