### PR TITLE
Update map and assets

### DIFF
--- a/Content/Characters/Heroes/Mannequin/Meshes/SK_Mannequin.uasset
+++ b/Content/Characters/Heroes/Mannequin/Meshes/SK_Mannequin.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ffd390ce46a661639111305167ea1034e574a014ff420b733ecaa117484095d
-size 179538
+oid sha256:6ac48a90113f92c62f29ff95d76f6a545ee78bc6eb99bdfc11e6f0e439bae820
+size 179977

--- a/Content/Team02/Maps/PlayGround.umap
+++ b/Content/Team02/Maps/PlayGround.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af6e62f827014ed4a817a2c5e711098c3575286d56a8d7f5809def8788a8d2ee
-size 106473
+oid sha256:fadec4b1faafd1904cebf44d7726f5f3f09e52ea1869d6d7b20047fa25ae0bd1
+size 112368

--- a/Content/Team02/Monster/GunNPC/Character/SKM_GunNPC_Test.uasset
+++ b/Content/Team02/Monster/GunNPC/Character/SKM_GunNPC_Test.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e223aae5c1494a62c48c431281cacfea2be80f6af2dfed9ce753131fe9b30b3
+oid sha256:74838ef2d577251ac082b9a0da341e7d6f06c69f65cfd92ee49769e625bfaa50
 size 28744164


### PR DESCRIPTION
Updated PlayGround.umap file and replaced/modified SK_Mannequin and SKM_GunNPC_Test assets as part of asset improvements.