### PR TITLE
게임오버 UI, 게임클리어 UI 기능 연결

### DIFF
--- a/Content/Team02/UI/OutGame/WBP_GameClearMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_GameClearMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b986efa1c1d0019984de1d9bf5c0ebdf7dd7963066eb5f787f7b624e4b28f042
-size 44851
+oid sha256:584a886267fa0315fd29b728d678abab5a76b85d113a26c6c42ac7cfac7cb44f
+size 44773

--- a/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:edb59edd88d374c9228dde75de48a4d2520db66d14477424babc4317d6e522c8
-size 63533
+oid sha256:4dc2632762ede191568decaf7a30ed6200920986f728e3fc1496d0ab8e058d1e
+size 64222

--- a/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_GameOverMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b0e422a00b2c09f0c62cd13b29a9f5f8d69224e983ad20ee52bbfe2f52819d6
-size 63164
+oid sha256:edb59edd88d374c9228dde75de48a4d2520db66d14477424babc4317d6e522c8
+size 63533

--- a/Content/Team02/UI/OutGame/WBP_MainMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_MainMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4dd7ccebb14b64420070f74ee81c31f5f97115546a24aa16c31532c51defd75
-size 57041
+oid sha256:71533ff21a3c0cf93520ed15f5d747497246778ec6fefc19f57538e60802d729
+size 56113

--- a/Content/Team02/UI/OutGame/WBP_OptionsMenu.uasset
+++ b/Content/Team02/UI/OutGame/WBP_OptionsMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b703852ae2322818221c0a89622ee2f6a3229793d957f0aa6a95aea1d644428
-size 45787
+oid sha256:fd15d288eb5d8aba7716f2644428eaa725a0b83ff7f98fce39e988aad3c8ba1a
+size 46028

--- a/Source/Character/TPlayerCharacter.cpp
+++ b/Source/Character/TPlayerCharacter.cpp
@@ -260,15 +260,29 @@ void ATPlayerCharacter::HandleOnPostCharacterDead()
   // 4. UI 띄우기
   if (APlayerController* PC = Cast<APlayerController>(GetController()))
   {
-    
+    // 게임 일시정지
+    if (!UGameplayStatics::IsGamePaused(GetWorld()))
+    {
+      UGameplayStatics::SetGamePaused(GetWorld(), true);
+    }
+
+    // UI 표시
     if (GameOverWidgetClass)
     {
       UUserWidget* GameOverUI = CreateWidget<UUserWidget>(PC, GameOverWidgetClass);
       if (GameOverUI)
       {
         GameOverUI->AddToViewport();
+
+        // UI 전용 입력 모드 설정
+        FInputModeUIOnly InputMode;
+        if (TSharedPtr<SWidget> FocusWidget = GameOverUI->TakeWidget())
+        {
+          InputMode.SetWidgetToFocus(FocusWidget.ToSharedRef());
+        }
+        InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+        PC->SetInputMode(InputMode);
         PC->bShowMouseCursor = true;
-        PC->SetInputMode(FInputModeUIOnly());
       }
     }
   }

--- a/Source/Team02/TGameMode.cpp
+++ b/Source/Team02/TGameMode.cpp
@@ -172,27 +172,33 @@ void ATGameMode::OnZoneOverlap(int32 ZoneIndex)
 // }
 
 // 플레이어 리스폰
+// 플레이어 리스폰
 void ATGameMode::RespawnPlayer(AController* DeadController)
 {
 	if (!DeadController) return;
 
-	// PlayerController로 캐스팅
+	// 1. 게임 일시정지 해제
+	if (UGameplayStatics::IsGamePaused(GetWorld()))
+	{
+		UGameplayStatics::SetGamePaused(GetWorld(), false);
+	}
+
+	// 2. 입력 모드 게임 전용으로 변경
 	if (APlayerController* PC = Cast<APlayerController>(DeadController))
 	{
-		// 플레이어 입력을 게임 전용 모드로 설정 (UI 입력 차단, 마우스 커서 숨김)
 		FInputModeGameOnly InputMode;
 		PC->SetInputMode(InputMode);
 		PC->bShowMouseCursor = false; // 커서 숨기기
 	}
 
-	// 기존 Pawn 제거
+	// 3. 기존 Pawn 제거
 	if (APawn* Pawn = DeadController->GetPawn())
 	{
 		DeadController->UnPossess();
 		Pawn->Destroy();
 	}
 
-	// 리스폰 위치 결정
+	// 4. 리스폰 위치 결정
 	FTransform RespawnTransform;
 	if (LastCapturedPoint)
 	{
@@ -207,7 +213,7 @@ void ATGameMode::RespawnPlayer(AController* DeadController)
 		return;
 	}
 
-	// 새 Pawn 스폰 후 Possess
+	// 5. 새 Pawn 스폰 후 Possess
 	APawn* NewPawn = SpawnDefaultPawnAtTransform(DeadController, RespawnTransform);
 	if (!NewPawn) return;
 


### PR DESCRIPTION
게임오버 UI 내 Respawn, Restart, Quit 기능 연결
게임클리어 UI 내 Restart, Quit 기능 연결

Title UI 및 OptionsMenu UI 이미지 화면 비율 조정

플레이어 사망 시 게임 일시정지 후 게임오버 UI 띄우기
게임오버 UI 내 Respawn 버튼 클릭시 게임 일시정지 해제 후 입력 모드 게임 전용으로 전환