### PR TITLE
UI 및 게임플레이 개선

### DIFF
--- a/Content/Team02/Maps/MainLevel.umap
+++ b/Content/Team02/Maps/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd1c4a70a95da63dab6a4c116469660337c3d1bd5154d80ff375489679ffa565
-size 1893476
+oid sha256:cf8025cfc3f84126d21a33f9cfbe77acee56c0ee75146e335066fb66033af55f
+size 1895980

--- a/Content/Team02/Maps/MainLevel.umap
+++ b/Content/Team02/Maps/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf8025cfc3f84126d21a33f9cfbe77acee56c0ee75146e335066fb66033af55f
-size 1895980
+oid sha256:37646dae7b91eafebfec1ec2ab227bd3a7a34883974eb1ac3d3d8bc9f6e08da0
+size 1899366

--- a/Content/Team02/Monster/SwordNPC/Blueprint/BP_SwordNPC.uasset
+++ b/Content/Team02/Monster/SwordNPC/Blueprint/BP_SwordNPC.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a25f863bb462ba4efec3d75a8951d114f3b3e763a26322fc3d3551e3f6abc84
-size 79559
+oid sha256:b8d4169ab19fde612e1b6513d64cec42b5e3507ad098974ae016876d5a3cc333
+size 81219

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9cf4605647255c92bb97a90ecfb1589f7c5d664fc380bc9799fc9de0845b8921
-size 53272
+oid sha256:3bbf894cddaa216ea9cb1fe6e8d4c17d4bd4239acd61bf5cd217e9cc38530605
+size 54025

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3bbf894cddaa216ea9cb1fe6e8d4c17d4bd4239acd61bf5cd217e9cc38530605
-size 54025
+oid sha256:4cdf6f22622336dfbadcbf49d7fae95c042403f542e39181d9facba046df6ae7
+size 54005

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76c57287163f2c0ee465f53cca65af79d7ad8859b3d9c6389f4df75fc6395c0e
-size 50993
+oid sha256:da6f7dbb1d8c56317062be901d9768ecb218b9029297c987b6a646fb0bd33b8f
+size 53385

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da6f7dbb1d8c56317062be901d9768ecb218b9029297c987b6a646fb0bd33b8f
-size 53385
+oid sha256:9cf4605647255c92bb97a90ecfb1589f7c5d664fc380bc9799fc9de0845b8921
+size 53272

--- a/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarComponent.cpp
@@ -36,6 +36,9 @@ void UTMonsterHealthBarComponent::BeginPlay()
 	}
     
 	InitializeHealthBar();
+
+	//위젯 생성 이후 몬스터 이름 초기화
+	SetupMonsterNameAfterWidgetCreation();
 	
 }
 
@@ -78,8 +81,6 @@ void UTMonsterHealthBarComponent::TickComponent(float DeltaTime, ELevelTick Tick
 			HealthBarWidgetComponent->SetWorldRotation(LookRotation);
 		}
 	}
-
-
 	
 }
 
@@ -100,4 +101,42 @@ void UTMonsterHealthBarComponent::InitializeHealthBar()
 		// 오류 점검 로그
 		UE_LOG(LogTemp, Warning, TEXT("Widget setup complete"));
 	}
+}
+
+void UTMonsterHealthBarComponent::InitializeMonsterName()
+{
+	if (HealthBarWidgetComponent)
+	{
+		if (UTMonsterHealthBarWidget* MonsterWidget = Cast<UTMonsterHealthBarWidget>(HealthBarWidgetComponent->GetUserWidgetObject()))
+		{
+			MonsterWidget->SetMonsterNameByType(GetOwner());
+			UE_LOG(LogTemp, Warning, TEXT("✅ Monster name initialized for: %s"), 
+				   GetOwner() ? *GetOwner()->GetName() : TEXT("Unknown"));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("❌ Failed to cast to UTMonsterHealthBarWidget"));
+		}
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("❌ HealthBarWidgetComponent is null"));
+	}
+}
+
+void UTMonsterHealthBarComponent::SetupMonsterNameAfterWidgetCreation()
+{
+	// 위젯이 아직 생성되지 않았다면 잠시 대기 후 재시도
+	if (!HealthBarWidgetComponent->GetUserWidgetObject())
+	{
+		// 0.1초 후 다시 시도
+		GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
+		{
+			SetupMonsterNameAfterWidgetCreation();
+		});
+		return;
+	}
+    
+	// 위젯이 준비되면 몬스터 이름 초기화
+	InitializeMonsterName();
 }

--- a/Source/Team02/UI/InGame/TMonsterHealthBarComponent.h
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarComponent.h
@@ -26,6 +26,10 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void InitializeHealthBar();
 
+	//위잿 생성시 자동으로 몬스터 이름 설정
+	UFUNCTION(BlueprintCallable)
+	void InitializeMonsterName();
+
 protected:
 	// widget component(world space UI)
 	UPROPERTY(VisibleAnywhere,BlueprintReadOnly)
@@ -42,5 +46,9 @@ protected:
 	// 오너 캐릭터 레퍼런스
 	UPROPERTY()
 	TObjectPtr<ATCharacterBase> OwnerCharacter;
+
+private:
+	//내부적으로 사용하는 헬퍼함수
+	void SetupMonsterNameAfterWidgetCreation();
 		
 };

--- a/Source/Team02/UI/InGame/TMonsterHealthBarWidget.cpp
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarWidget.cpp
@@ -18,11 +18,43 @@ void UTMonsterHealthBarWidget::UpdateHealthBar(float CurrentHP,float MaxHP)
 	}
 }
 
-void UTMonsterHealthBarWidget::SetMonsterName(const FString& Name)
+void UTMonsterHealthBarWidget::SetMonsterNameByType(AActor* OwnerMonster)
+{
+	if (!OwnerMonster || !MonsterNameText)
+	{
+		UE_LOG(LogTemp,Error,TEXT("OwnerMonster or MonsterNameText is null"));
+		return;
+	}
+
+	FString ClassName=OwnerMonster->GetClass()->GetName();
+	FString MonsterTypeName;
+	
+	// 클래스 이름으로 몬스터 타입 구분
+	if (ClassName.Contains(TEXT("GunNPC")) || ClassName.Contains(TEXT("Gun")))
+	{
+		MonsterTypeName = TEXT("Gun Enemy");
+	}
+	else if (ClassName.Contains(TEXT("SwordNPC")) || ClassName.Contains(TEXT("Sword")))
+	{
+		MonsterTypeName = TEXT("Sword Enemy");
+	}
+	else
+	{
+		MonsterTypeName = TEXT("Enemy");
+	}
+	
+	MonsterNameText->SetText(FText::FromString(MonsterTypeName));
+	UE_LOG(LogTemp, Warning, TEXT("🏷️ Monster name set to: %s for %s"), 
+		  *MonsterTypeName, *OwnerMonster->GetName());
+	
+}
+
+
+void UTMonsterHealthBarWidget::SetMonsterName(const FString& NewName)
 {
 	if (MonsterNameText)
 	{
-		MonsterNameText->SetText(FText::FromString(Name));
+		MonsterNameText->SetText(FText::FromString(NewName));
 	}
 }
 

--- a/Source/Team02/UI/InGame/TMonsterHealthBarWidget.h
+++ b/Source/Team02/UI/InGame/TMonsterHealthBarWidget.h
@@ -16,9 +16,9 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void UpdateHealthBar(float CurrentHP,float MaxHP);
 
-	// monster name function
+	// 직접 몬스터 이름을 설정하는 함수
 	UFUNCTION(BlueprintCallable)
-	void SetMonsterName(const FString& Name);
+	void SetMonsterName(const FString& NewName);
 
 	// show or hide UI wigets
 	UFUNCTION(BlueprintCallable)
@@ -26,6 +26,12 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	void HideHealthBar();
+
+	//몬스터 타입에 따라 이름 설정하는 함수
+	UFUNCTION(BLueprintCallable)
+	void SetMonsterNameByType(AActor* OwnerMonster);
+
+
 
 protected:
 	// widget binding

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -1,4 +1,7 @@
 #include "TPlayerUIWidget.h"
+
+#include "Character/TNonPlayerCharacter.h"
+#include "Character/TNonPlayerCharacterSword.h"
 #include "Components/ProgressBar.h"
 #include "Components/TextBlock.h"
 #include "Components/Image.h"
@@ -331,33 +334,64 @@ void UTPlayerUIWidget::UpdateWeaponName(const FString& WeaponName)
 
 void UTPlayerUIWidget::ShowHitMarker()
 {
-	if (Crosshair)
+	if (HitMarker)
 	{
-		if (UImage* CrosshairImage = Cast<UImage>(Crosshair))
+		// 🔧 UImage로 캐스팅해서 함수 사용
+		if (UImage* HitMarkerImage = Cast<UImage>(HitMarker))
 		{
-			// Image 위젯의 색상 변경
-			CrosshairImage->SetBrushTintColor(FSlateColor(FLinearColor::White));
+			// 기존 타이머 정리
+			GetWorld()->GetTimerManager().ClearTimer(HitMarkerTimerHandle);
             
-			// 0.15초 후 원래 색으로 복구
+			// 🎯 히트마커 표시
+			HitMarkerImage->SetVisibility(ESlateVisibility::Visible);
+			HitMarkerImage->SetOpacity(1.0f);
+            
+			// 📏 임팩트 효과: 크기 변화
+			HitMarkerImage->SetRenderScale(FVector2D(1.8f, 1.8f)); // 1.8배로 크게 시작
+            
+			// ⚡ 0.1초 후 원래 크기로
+			FTimerHandle ScaleTimer;
 			GetWorld()->GetTimerManager().SetTimer(
-				HitMarkerTimerHandle,
-				[this, CrosshairImage]()
+				ScaleTimer,
+				[this, HitMarkerImage]()
 				{
-					if (CrosshairImage)
+					if (HitMarkerImage && IsValid(HitMarkerImage))
 					{
-						// 원래 빨간색으로 복구
-						CrosshairImage->SetBrushTintColor(FSlateColor(FLinearColor::Red));
+						HitMarkerImage->SetRenderScale(FVector2D(1.0f, 1.0f));
 					}
 				},
-				1.0f,
+				0.1f,
 				false
 			);
             
-			UE_LOG(LogTemp, Warning, TEXT("✅ Hit marker shown with tint color!"));
+			// ⏱️ 0.15초 후 히트마커 숨김
+			GetWorld()->GetTimerManager().SetTimer(
+				HitMarkerTimerHandle,
+				[this, HitMarkerImage]()
+				{
+					if (HitMarkerImage && IsValid(HitMarkerImage))
+					{
+						HitMarkerImage->SetVisibility(ESlateVisibility::Hidden);
+						UE_LOG(LogTemp, Warning, TEXT("🎯 Red hitmarker hidden"));
+					}
+				},
+				0.15f,
+				false
+			);
+            
+			UE_LOG(LogTemp, Warning, TEXT("🔴 RED HITMARKER shown! Scale: 1.8x -> 1.0x"));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("❌ HitMarker is not UImage! Check widget type."));
 		}
 	}
 	else
 	{
-		UE_LOG(LogTemp, Error, TEXT("❌ Crosshair widget is null!"));
+		UE_LOG(LogTemp, Error, TEXT("❌ HitMarker widget not found! Check Blueprint binding."));
 	}
 }
+
+
+
+

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -364,7 +364,7 @@ void UTPlayerUIWidget::ShowHitMarker()
 				false
 			);
             
-			// ⏱️ 0.15초 후 히트마커 숨김
+			// ⏱️ 0.3초 후 히트마커 숨김
 			GetWorld()->GetTimerManager().SetTimer(
 				HitMarkerTimerHandle,
 				[this, HitMarkerImage]()
@@ -375,7 +375,7 @@ void UTPlayerUIWidget::ShowHitMarker()
 						UE_LOG(LogTemp, Warning, TEXT("🎯 Red hitmarker hidden"));
 					}
 				},
-				0.15f,
+				0.3f,
 				false
 			);
             

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.h
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.h
@@ -62,7 +62,9 @@ public:
 	//히트 마커 함수 추가
 	UFUNCTION(BlueprintCallable)
 	void ShowHitMarker();
+
 	
+
 
 
 protected:
@@ -98,7 +100,10 @@ protected:
 	TObjectPtr<UTextBlock> WeaponNameText;
 
 	UPROPERTY(meta=(BindWidget))
-	TObjectPtr<UWidget> Crosshair;// 기존 크로스헤어를 히트마커로 활용
+	TObjectPtr<UWidget> Crosshair;
+
+	UPROPERTY(meta=(BindWidget))
+	TObjectPtr<UWidget> HitMarker; 
 
 	//타이밍 애니메이션 변수
 	UPROPERTY()
@@ -127,5 +132,15 @@ private:
 
 	//히트 마커 타이머
 	FTimerHandle HitMarkerTimerHandle;
+
+	//힌트 감지 타이머
+	FTimerHandle HitDetectionTimer;
+
+	// 이전 상태 저장용
+	int32 LastWeaponAmmo = -1;
+	TArray<float> LastMonsterHPs;
+	bool bLastFireButtonPressed = false;
+    
+	
 	
 };

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -162,7 +162,7 @@ void UTUIManager::UpdateWeaponInfo()
 
 			UE_LOG(LogTemp,Warning,TEXT("Weapon changed to: %s"), *WeaponName);
 
-			//새로운 무기 습득 감지 로직 추가
+			//첫번째 무기 습득감지
 			if (bFirstCaptureCompleted && !bWeaponPickedUp)
 			{
 				// 새로운 무기인지 확인(기본 무기가 아닌 경우)
@@ -178,6 +178,21 @@ void UTUIManager::UpdateWeaponInfo()
 				else
 				{
 					UE_LOG(LogTemp, Warning, TEXT("🔫 Basic weapon detected: %s (not counting as new weapon)"), *WeaponName);
+				}
+			}
+			//두번쨰 무기 습득 감지(2거점 가기 전 라이플)
+			else if (bWeaponPickedUp && !bSecondWeaponPickedUp && CurrentCaptureIndex==1)
+			{
+				//라이플이나 새로운 무기인지 확인
+				if (WeaponName != TEXT("Pistol") && WeaponName !=TEXT("No Weapon"))
+				{
+					//이전에 먹은 무기와 다른 무기인지 확인
+					if (PreviousWeapon && WeaponName != PreviousWeapon->GetWeaponTypeString())
+					{
+						bSecondWeaponPickedUp=true;
+						UE_LOG(LogTemp, Warning, TEXT("🔫 Second weapon '%s' picked up!"), *WeaponName);
+						UpdateMissionState();// 미션 업데이트
+					}
 				}
 			}
 			else
@@ -332,87 +347,94 @@ void UTUIManager::UpdateMissionProgress()
 	UpdateMissionState();
 }
 
+// TUIManager.cpp의 UpdateMissionState() 함수를 이것으로 교체하세요
+
 void UTUIManager::UpdateMissionState()
 {
     FString NewObjective;
     
     // 임무 확인 로그
-	UE_LOG(LogTemp, Warning, TEXT("🎯 Mission State Update:"));
-	UE_LOG(LogTemp, Warning, TEXT("  bSecondCaptureCompleted: %s"), bSecondCaptureCompleted ? TEXT("YES") : TEXT("NO"));
-	UE_LOG(LogTemp, Warning, TEXT("  bFirstCaptureCompleted: %s"), bFirstCaptureCompleted ? TEXT("YES") : TEXT("NO"));
-	UE_LOG(LogTemp, Warning, TEXT("  bWeaponPickedUp: %s"), bWeaponPickedUp ? TEXT("YES") : TEXT("NO"));
-	UE_LOG(LogTemp, Warning, TEXT("  bWaveCompleted: %s"), bWaveCompleted ? TEXT("YES") : TEXT("NO"));
-	UE_LOG(LogTemp, Warning, TEXT("  bWaveActive: %s"), bWaveActive ? TEXT("YES") : TEXT("NO"));
-	UE_LOG(LogTemp, Warning, TEXT("  CurrentCaptureIndex: %d"), CurrentCaptureIndex);
+    UE_LOG(LogTemp, Warning, TEXT("🎯 Mission State Update:"));
+    UE_LOG(LogTemp, Warning, TEXT("  bSecondCaptureCompleted: %s"), bSecondCaptureCompleted ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  bFirstCaptureCompleted: %s"), bFirstCaptureCompleted ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  bWeaponPickedUp: %s"), bWeaponPickedUp ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  bSecondWeaponPickedUp: %s"), bSecondWeaponPickedUp ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  bWaveCompleted: %s"), bWaveCompleted ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  bWaveActive: %s"), bWaveActive ? TEXT("YES") : TEXT("NO"));
+    UE_LOG(LogTemp, Warning, TEXT("  CurrentCaptureIndex: %d"), CurrentCaptureIndex);
 
-	// 게임 완료
-	if (bSecondCaptureCompleted)
-	{
-		NewObjective=TEXT("Victory! Game Complete!");
-		//승리 이벤트 발생
-		OnVictoryEvent.Broadcast();
-		UE_LOG(LogTemp,Warning,TEXT("Game Completed! All Capture points secured!!"));
-	}
+    // 게임 완료
+    if (bSecondCaptureCompleted)
+    {
+        NewObjective = TEXT("Victory!");  // 짧게 수정
+        //승리 이벤트 발생
+        OnVictoryEvent.Broadcast();
+        UE_LOG(LogTemp, Warning, TEXT("Game Completed! All Capture points secured!!"));
+    }
+    // 2거점 점령 관련 (두 번째 무기 습득 완료 후)
+    else if (bSecondWeaponPickedUp && CurrentCaptureIndex == 1)
+    {
+        if (bNearCapturePoint && bCapturePhase)
+        {
+            NewObjective = TEXT("Capture Point 2");  // 짧게 수정
+        }
+        else if (bNearCapturePoint && !bCapturePhase)
+        {
+            NewObjective = TEXT("Enter Point 2");  // 짧게 수정
+            bCapturePhase = true;
+        }
+        else
+        {
+            NewObjective = TEXT("Move to Point 2");  // 짧게 수정
+        }
+    }
+    // 두 번째 무기 습득 단계 (첫 번째 무기 습득 후, 2거점 가기 전)
+    else if (bWeaponPickedUp && !bSecondWeaponPickedUp && CurrentCaptureIndex == 1)
+    {
+        NewObjective = TEXT("Get Rifle");  // 새로 추가
+    }
+    // 첫 번째 무기 습득 단계 (1거점 완료 후)
+    else if (bFirstCaptureCompleted && !bWeaponPickedUp)
+    {
+        NewObjective = TEXT("Get Shotgun");  // 짧게 수정
+    }
+    // 1거점 점령 관련
+    else if (bWaveCompleted && CurrentCaptureIndex == 0)
+    {
+        if (bNearCapturePoint && bCapturePhase)
+        {
+            NewObjective = TEXT("Capture Point 1");  // 짧게 수정
+        }
+        else if (bNearCapturePoint && !bCapturePhase)
+        {
+            NewObjective = TEXT("Enter Point 1");  // 짧게 수정
+            bCapturePhase = true;
+        }
+        else
+        {
+            NewObjective = TEXT("Move to Point 1");  // 짧게 수정
+        }
+    }
+    //몬스터 처치 관련
+    else if (bWaveActive || TrackedMonsters.Num() > 0)
+    {
+        int32 SpawnerBasedMax = 0;
+        for (ATEnemySpawner* Spawner : RegisteredSpawners)
+        {
+            if (Spawner)
+            {
+                SpawnerBasedMax += Spawner->MaxSpawnCount;
+            }
+        }
 
-	// 무기 습득 완료 이후 2거점으로 이동
-    else if (bWeaponPickedUp && CurrentCaptureIndex==1)
-	{
-    	if (bNearCapturePoint && bCapturePhase)
-    	{
-    		NewObjective=TEXT("Capture Second point!");
-    	}
-    	else if (bNearCapturePoint && !bCapturePhase)
-    	{
-    		NewObjective=TEXT("Enter Second Point!");
-    		bCapturePhase=true;
-    	}
-	    else
-	    {
-		    NewObjective=TEXT("Move to Second Point!");
-	    }
-	}
-	// 1거점 완료후 무기 습득 하라고 텍스트 갱신 하기
-	else if (bFirstCaptureCompleted && !bWeaponPickedUp)
-	{
-		NewObjective=TEXT("Get New Weapon!");
-	}
-	// 1거점 점령 관련
-	else if (bWaveCompleted && CurrentCaptureIndex==0)
-	{
-		if (bNearCapturePoint && bCapturePhase)
-		{
-			NewObjective=TEXT("Capture the First Point!");
-		}
-		else if (bNearCapturePoint && !bCapturePhase)
-		{
-			NewObjective=TEXT("Enter First Point!");
-			bCapturePhase=true;
-		}
-		else
-		{
-			NewObjective=TEXT("Move to First Point!");
-		}
-	}
-	//몬스터 처치 관련
-	else if (bWaveActive || TrackedMonsters.Num()>0)
-	{
-		int32 SpawnerBasedMax=0;
-		for (ATEnemySpawner* Spawner: RegisteredSpawners)
-		{
-			if (Spawner)
-			{
-				SpawnerBasedMax+=Spawner->MaxSpawnCount;
-			}
-		}
-
-		int32 RemainingCount=FMath::Max(0,SpawnerBasedMax-MonsterKillCount);
-		NewObjective=FString::Printf(TEXT("Eliminate enemies (%d remaining)"),RemainingCount);
-	}
-	else
-	{
-		NewObjective=TEXT("Eliminate all enemies");
-	}
-	
+        int32 RemainingCount = FMath::Max(0, SpawnerBasedMax - MonsterKillCount);
+        NewObjective = FString::Printf(TEXT("Kill Enemies (%d left)"), RemainingCount);  // 짧게 수정
+    }
+    else
+    {
+        NewObjective = TEXT("Kill All Enemies");  // 짧게 수정
+    }
+    
     // 미션 목표가 실제로 변경되었을 때만 업데이트
     if (CurrentMissionObjective != NewObjective)
     {
@@ -886,6 +908,11 @@ void UTUIManager::RestartGameUI()
 	//히트 감지 변수 초기화
 	LastWeaponAmmo=-1;
 	LastMonsterHPs.Empty();
+
+	//무기 관련 초기화
+	bWeaponSpawned=false;
+	bWeaponPickedUp=false;
+	bSecondWeaponPickedUp=false;
 
 	//거점 관련 초기화
 	CurrentCaptureIndex=0;

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -8,9 +8,11 @@
 #include "Area/TCapturePoint.h"
 #include "EngineUtils.h"
 #include "Character/TNonPlayerCharacter.h"
+#include "Character/TNonPlayerCharacterSword.h"
 #include "Spawner/TEnemySpawner.h"
-#include "TAIBossMonster/TAIBossMonster.h"
+#include "Engine/DamageEvents.h"
 #include "TGameMode.h"
+#include "Engine/Engine.h"
 #include "UnifiedBuffer.h"
 
 void UTUIManager::Initialize(FSubsystemCollectionBase& Collection)
@@ -28,6 +30,8 @@ void UTUIManager::Deinitialize()
 	{
 		GetWorld()->GetTimerManager().ClearTimer(UIUpdateTimerHandle);
 		GetWorld()->GetTimerManager().ClearTimer(MonsterMonitorTimer);
+		GetWorld()->GetTimerManager().ClearTimer(HitDetectionTimer);
+		
 	}
 	Super::Deinitialize();
 }
@@ -64,7 +68,7 @@ void UTUIManager::CreatePlayerUI()
 		{
 			UE_LOG(LogTemp, Error, TEXT("❌ Failed to get GameMode reference in CreatePlayerUI!"));
 		}
-
+		
 		
 		PlayerUIWidget = CreateWidget<UTPlayerUIWidget>(GetWorld(), PlayerUIWidgetClass);
 		if (PlayerUIWidget)
@@ -79,6 +83,9 @@ void UTUIManager::CreatePlayerUI()
 				&UTUIManager::UpdateAllUI,
 				0.1f,
 				true);
+
+			//히트 감지 시작
+			StartHitDetection();
 			
 			// 거점 자동 검색 및 등록(UI 생성 이후)
 			FindAndRegisterCapturePoints();
@@ -86,6 +93,8 @@ void UTUIManager::CreatePlayerUI()
 			// 스포너 및 몬스터 모너터링 시작
 			FindAndRegisterEnemySpawners();
 			StartMonitoringMonsters();
+
+			
 
 			//초기 미션 설정
 			CurrentMissionObjective=TEXT("Mission:");
@@ -110,6 +119,8 @@ void UTUIManager::CreatePlayerUI()
 		}
 	}
 }
+
+
 
 void UTUIManager::SetPlayerCharacter(ATCharacterBase* PlayerChar)
 {
@@ -352,7 +363,7 @@ void UTUIManager::UpdateMissionState()
     	}
     	else if (bNearCapturePoint && !bCapturePhase)
     	{
-    		NewObjective=TEXT("Enter and start capture!");
+    		NewObjective=TEXT("Go second control point!");
     		bCapturePhase=true;
     	}
 	    else
@@ -453,7 +464,7 @@ void UTUIManager::StartMonitoringMonsters()
 			0.5f,
 			true);
 
-		UE_LOG(LogTemp,Warning,TEXT("Monster monitering startered!"));
+		UE_LOG(LogTemp,Warning,TEXT("Monster monitoring started!"));
 	}
 }
 
@@ -704,7 +715,6 @@ void UTUIManager::UnlockWeapon()
 
 
 
-
 void UTUIManager::UpdateAllUI()
 {
 	// 기존 UI 업데이트
@@ -873,6 +883,10 @@ void UTUIManager::RestartGameUI()
 	LastWaveMonsterCount=0;
 	TotalWaveMonsters=0;
 
+	//히트 감지 변수 초기화
+	LastWeaponAmmo=-1;
+	LastMonsterHPs.Empty();
+
 	//거점 관련 초기화
 	CurrentCaptureIndex=0;
 	if (AllCapturePoints.IsValidIndex(0))
@@ -903,14 +917,17 @@ void UTUIManager::RestartGameUI()
 		PlayerUIWidget->HideEnemyIncomingAlarm();
 	}
 
+	
 	//타이머 초기화
 	if (GetWorld())
 	{
 		GetWorld()->GetTimerManager().ClearTimer(MonsterMonitorTimer);
 		GetWorld()->GetTimerManager().ClearTimer(UIUpdateTimerHandle);
+		GetWorld()->GetTimerManager().ClearTimer(HitDetectionTimer);
 
 		//모니터링 재시작
 		StartMonitoringMonsters();
+		StartHitDetection();
 
 		//UI업데이트 타이머 재시작
 		GetWorld()->GetTimerManager().SetTimer(
@@ -942,17 +959,119 @@ void UTUIManager::RestartGameUI()
 	
 }
 
-void UTUIManager::TestHitMarker()
+void UTUIManager::StartHitDetection()
 {
-	if (PlayerUIWidget)
-	{
-		PlayerUIWidget->ShowHitMarker();
-		UE_LOG(LogTemp,Warning,TEXT("Test hit marker called"));
-	}
-	else
-	{
-		UE_LOG(LogTemp,Warning,TEXT("PlayerUIWidget is null!"));
-	}
+    if (GetWorld() && !HitDetectionTimer.IsValid())
+    {
+        GetWorld()->GetTimerManager().SetTimer(
+            HitDetectionTimer,
+            this,
+            &UTUIManager::CheckForHits,
+            0.1f,  // 0.1초마다 체크
+            true   // 반복
+        );
+        
+        UE_LOG(LogTemp, Warning, TEXT("🎯 Hit detection started"));
+    }
 }
 
+void UTUIManager::StopHitDetection()
+{
+    if (GetWorld() && HitDetectionTimer.IsValid())
+    {
+        GetWorld()->GetTimerManager().ClearTimer(HitDetectionTimer);
+        UE_LOG(LogTemp, Warning, TEXT("🎯 Hit detection stopped"));
+    }
+}
 
+void UTUIManager::CheckForHits()
+{
+    // 플레이어와 무기 확인
+    if (!PlayerCharacter) return;
+    
+    ATPlayerCharacter* Player = Cast<ATPlayerCharacter>(PlayerCharacter);
+    if (!Player) return;
+    
+    ATWeaponBase* Weapon = Player->CurrentWeapon;
+    if (!Weapon) return;
+    
+    // 🔫 무기 발사 감지 (탄약 변화)
+    int32 CurrentAmmo = Weapon->GetCurrentAmmo();
+    
+    if (LastWeaponAmmo > 0 && CurrentAmmo < LastWeaponAmmo)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("🔫 Weapon fired! Ammo: %d -> %d"), LastWeaponAmmo, CurrentAmmo);
+        
+        // 🎯 몬스터 HP 변화 체크
+        if (CheckMonsterHPChanges())
+        {
+            // 히트마커 표시!
+            if (PlayerUIWidget)
+            {
+                PlayerUIWidget->ShowHitMarker();
+                UE_LOG(LogTemp, Warning, TEXT("🎯 HIT DETECTED! Showing red hitmarker"));
+            }
+        }
+        else
+        {
+            UE_LOG(LogTemp, Warning, TEXT("❌ Miss detected - no monster HP change"));
+        }
+    }
+    
+    // 상태 업데이트
+    LastWeaponAmmo = CurrentAmmo;
+    UpdateMonsterHPList();
+}
+
+bool UTUIManager::CheckMonsterHPChanges()
+{
+    // 현재 추적 중인 모든 몬스터의 HP 체크
+    for (int32 i = 0; i < TrackedMonsters.Num(); i++)
+    {
+        if (TrackedMonsters[i] && IsValid(TrackedMonsters[i]))
+        {
+            float CurrentHP = TrackedMonsters[i]->GetCurrentHP();
+            
+            // 이전 HP와 비교
+            if (i < LastMonsterHPs.Num())
+            {
+                if (CurrentHP < LastMonsterHPs[i])
+                {
+                    UE_LOG(LogTemp, Warning, TEXT("🩸 Monster %s HP decreased: %.1f -> %.1f"), 
+                           *TrackedMonsters[i]->GetName(), LastMonsterHPs[i], CurrentHP);
+                    return true; // 히트 감지!
+                }
+            }
+        }
+    }
+    
+    return false; // 히트 없음
+}
+
+void UTUIManager::UpdateMonsterHPList()
+{
+    LastMonsterHPs.Empty();
+    
+    // 현재 추적 중인 모든 몬스터의 HP 저장
+    for (ATNonPlayerCharacter* Monster : TrackedMonsters)
+    {
+        if (Monster && IsValid(Monster))
+        {
+            LastMonsterHPs.Add(Monster->GetCurrentHP());
+        }
+    }
+}
+
+// ===== 기존 TestHitMarker 함수 수정 =====
+void UTUIManager::TestHitMarker()
+{
+    if (PlayerUIWidget)
+    {
+        PlayerUIWidget->ShowHitMarker();
+        UE_LOG(LogTemp, Warning, TEXT("🎯 Test red hitmarker called"));
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("PlayerUIWidget is null!"));
+    }
+}

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -359,38 +359,38 @@ void UTUIManager::UpdateMissionState()
 	{
     	if (bNearCapturePoint && bCapturePhase)
     	{
-    		NewObjective=TEXT("Capture the second point!");
+    		NewObjective=TEXT("Capture Second point!");
     	}
     	else if (bNearCapturePoint && !bCapturePhase)
     	{
-    		NewObjective=TEXT("Go second control point!");
+    		NewObjective=TEXT("Enter Second Point!");
     		bCapturePhase=true;
     	}
 	    else
 	    {
-		    NewObjective=TEXT("Move Second Control point!");
+		    NewObjective=TEXT("Move to Second Point!");
 	    }
 	}
 	// 1거점 완료후 무기 습득 하라고 텍스트 갱신 하기
 	else if (bFirstCaptureCompleted && !bWeaponPickedUp)
 	{
-		NewObjective=TEXT("Pick up new weapon from Control Point!");
+		NewObjective=TEXT("Get New Weapon!");
 	}
 	// 1거점 점령 관련
 	else if (bWaveCompleted && CurrentCaptureIndex==0)
 	{
 		if (bNearCapturePoint && bCapturePhase)
 		{
-			NewObjective=TEXT("Capture the first control point!");
+			NewObjective=TEXT("Capture the First Point!");
 		}
 		else if (bNearCapturePoint && !bCapturePhase)
 		{
-			NewObjective=TEXT("Enter and start capture!");
+			NewObjective=TEXT("Enter First Point!");
 			bCapturePhase=true;
 		}
 		else
 		{
-			NewObjective=TEXT("Move to first control point!");
+			NewObjective=TEXT("Move to First Point!");
 		}
 	}
 	//몬스터 처치 관련

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -244,6 +244,7 @@ private:
 	//무기 변경 관련 UI 함수
 	bool bWeaponSpawned=false;
 	bool bWeaponPickedUp=false;
+	bool bSecondWeaponPickedUp=false;
 
 	//히트마커 관련변수
 	int32 LastWeaponAmmo=-1;

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -5,6 +5,7 @@
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "TPlayerUIWidget.h"
 #include "Area/TCapturePoint.h"
+#include "Character/TNonPlayerCharacterSword.h"
 #include "TUIManager.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnVictoryDelegate);
@@ -102,8 +103,16 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void RestartGameUI();
 
+	//히트마커 제어함수
+	UFUNCTION(BlueprintCallable,Category="HitMarker")
+	void StartHitDetection();
+
+	UFUNCTION(BlueprintCallable,Category="HitMarker")
+	void StopHitDetection();
 
 	
+
+
 protected:
 	// UI widget class
 	UPROPERTY(EditAnywhere,BlueprintReadOnly)
@@ -235,6 +244,21 @@ private:
 	//무기 변경 관련 UI 함수
 	bool bWeaponSpawned=false;
 	bool bWeaponPickedUp=false;
+
+	//히트마커 관련변수
+	int32 LastWeaponAmmo=-1;
+	TArray<float> LastMonsterHPs;
+	FTimerHandle HitDetectionTimer;
+
+	//히트 감지 함수들
+	UFUNCTION()
+	void CheckForHits();
+
+	UFUNCTION()
+	bool CheckMonsterHPChanges();
+
+	UFUNCTION()
+	void UpdateMonsterHPList();
 
 	
 };


### PR DESCRIPTION
이 풀 리퀘스트에는 게임의 UI 및 게임플레이 메커니즘에 대한 업데이트와 개선 사항이 포함되어 있습니다.

SwordNPC 블루프린트에 체력 바를 다시 적용하고, MainLevel에서 테스트를 위해 시작 위치를 조정했습니다.

점령 지점 흐름 개선: 첫 번째 지점 점령 후 무기 획득 메시지를 추가하고, 미션 텍스트를 더 명확하게 수정했으며 WBP_PlayerUI에서 위치 및 크기를 조정했습니다.

다양한 상황에 맞춰 미션 목표 텍스트를 단순화하고 가독성을 향상시켰습니다.

몬스터 타입에 따른 이름 부여 로직을 추가하는 SetMonsterNameByType 함수를 구현하고, 관련 위젯/컴포넌트(TMonsterHealthBarWidget, TMonsterHealthBarComponent)를 업데이트했으며, 히트 마커 숨김 타이머를 0.3초로 증가시켰습니다.

UI 상태 업데이트를 개선하기 위해 WBP_PlayerUI 위젯 에셋을 수정했습니다.

StartHitDetection과 StopHitDetection 함수를 이용해 히트 감지 로직을 구현하고, 무기 타격 및 몬스터 HP 변화가 반영되도록 로직을 확장했습니다. 또한 HitMarker와 WBP_PlayerUI를 포함한 관련 위젯과 에셋을 업데이트했습니다.

그 외 테스트를 위해 연결된 에셋 및 시작 위치에 대한 소규모 조정이 포함되었습니다.