### PR TITLE
리펙토링 게임UI ,리스폰 로직

### DIFF
--- a/Content/Team02/Maps/MainLevel.umap
+++ b/Content/Team02/Maps/MainLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7e90e133d5cb35f4175e158bf2d1997364a0ba185a8a1fe536325168e9cbcc5
-size 2886751
+oid sha256:e122f055cd2c6f42a2773d35380a6af6ea9abb57a619ff3990655c3361befbae
+size 2886511

--- a/Content/Team02/UI/InGame/CaptureBar_Origin.uasset
+++ b/Content/Team02/UI/InGame/CaptureBar_Origin.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acd094e2dfb638fb5e29c620b84e48953e62f5964d0b2cf97280e96f9c005dba
+size 16591

--- a/Content/Team02/UI/InGame/HPBar_1_1.uasset
+++ b/Content/Team02/UI/InGame/HPBar_1_1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad7285f2373bb3484c95bb3c470d9e4ea091add8eb1967fc2ff85e1da3c31a68
+size 131015

--- a/Content/Team02/UI/InGame/HPBar_Orgin.uasset
+++ b/Content/Team02/UI/InGame/HPBar_Orgin.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd8cc98fcfdd4aefa18404680aac8e8d0ed2861670ec3d14e96e465a06c6e5b4
+size 215444

--- a/Content/Team02/UI/InGame/HPBar_Orgin.uasset
+++ b/Content/Team02/UI/InGame/HPBar_Orgin.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd8cc98fcfdd4aefa18404680aac8e8d0ed2861670ec3d14e96e465a06c6e5b4
-size 215444

--- a/Content/Team02/UI/InGame/HP_Bar_Progress.uasset
+++ b/Content/Team02/UI/InGame/HP_Bar_Progress.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3db776a2fbef0e1177ce226479e851b40e1420dcb03a91236bdbdf736eec4ed9
+size 64149

--- a/Content/Team02/UI/InGame/LAB디지털.uasset
+++ b/Content/Team02/UI/InGame/LAB디지털.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a4e7d4b13fff5c3b18d2ae1e86bfd7edf436274ea850c75e5eb44bc89c8d165
+size 962372

--- a/Content/Team02/UI/InGame/LAB디지털_Font.uasset
+++ b/Content/Team02/UI/InGame/LAB디지털_Font.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af39e601914553dcaec188c7e8b7e8bff81a43834645dd66924977f48cd19480
+size 2760

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9a30c7056887814b9d7e5d559243651c4a30a4abdd326c1d6aec4b2d3c6ba55
-size 54034
+oid sha256:418e3d9ea673d2d0e1304f5b33b73de4162cdcf9fb247908fe14a2a610efd6a9
+size 55050

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4cdf6f22622336dfbadcbf49d7fae95c042403f542e39181d9facba046df6ae7
-size 54005
+oid sha256:f9a30c7056887814b9d7e5d559243651c4a30a4abdd326c1d6aec4b2d3c6ba55
+size 54034

--- a/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
+++ b/Content/Team02/UI/InGame/WBP_PlayerUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:418e3d9ea673d2d0e1304f5b33b73de4162cdcf9fb247908fe14a2a610efd6a9
-size 55050
+oid sha256:37874eae3f9635932de113e3f0c500f20e4baf3b66c792cafed9064cb188912d
+size 59897

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -22,12 +22,25 @@ void UTPlayerUIWidget::UpdateHPBar(float CurrentHP, float MaxHP)
 	}
 }
 
-void UTPlayerUIWidget::UpdateAmmoInfo(int32 CurrentAmmo, int32 MaxAmmo)
+void UTPlayerUIWidget::UpdateAmmoInfo(int32 CurrentAmmo, int32 TotalAmmo)
 {
 	if (AmmoText)
 	{
-		FString AmmoString=FString::Printf(TEXT("%d/%d"),CurrentAmmo,MaxAmmo);
+		FString AmmoString;
+
+		//total ammo가 매우 큰값이면 무한대표시
+		if (TotalAmmo>=999)
+		{
+			AmmoString = FString::Printf(TEXT("%d/∞"), CurrentAmmo);
+		}
+		else
+		{
+			//일반적인 경우 (제한된 탄창)
+			AmmoString=FString::Printf(TEXT("%d/%d"),CurrentAmmo,TotalAmmo);
+		}
+
 		AmmoText->SetText(FText::FromString(AmmoString));
+		
 	}
 }
 

--- a/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
+++ b/Source/Team02/UI/InGame/TPlayerUIWidget.cpp
@@ -55,7 +55,7 @@ void UTPlayerUIWidget::ShowCaptureUI(const FString& AreaName)
 		CaptureLabel->SetText(FText::FromString(CaptureMessage));
 
 		//테스트 로그
-		UE_LOG(LogTemp,Warning,TEXT("CaptureLabel set to Visible!!"));
+		//UE_LOG(LogTemp,Warning,TEXT("CaptureLabel set to Visible!!"));
 	}
 	
 }
@@ -79,7 +79,7 @@ void UTPlayerUIWidget::HideCaptureUI()
 	}
 
 	//테스트 로그
-	UE_LOG(LogTemp,Warning,TEXT("Capture UI Hidden"));
+	//UE_LOG(LogTemp,Warning,TEXT("Capture UI Hidden"));
 }
 
 void UTPlayerUIWidget::UpdateCaptureProgress(float Progress)
@@ -129,19 +129,19 @@ void UTPlayerUIWidget::UpdateMissionObjective(const FString& ObjectiveText)
 		{
 			//처음 미션이거나 "Mission:" 상테에서 변경(타이핑 효과)
 			StartTypingAnimation(ObjectiveText);
-			UE_LOG(LogTemp,Warning,TEXT("Initial mission typing: %s"),*ObjectiveText);
+			//UE_LOG(LogTemp,Warning,TEXT("Initial mission typing: %s"),*ObjectiveText);
 		}
 		else if (bIsRealMissionChange)
 		{
 			// 진짜 미션 변경: 깜빡임 + 타이핑
 			StartFlashingAndChangeText(ObjectiveText);
-			UE_LOG(LogTemp, Warning, TEXT("Real mission change with effects: %s"), *ObjectiveText);
+			//UE_LOG(LogTemp, Warning, TEXT("Real mission change with effects: %s"), *ObjectiveText);
 		}
 		else
 		{
 			// 숫자만 변경: 즉시 업데이트 (깜빡임 없음)
 			ObjectText->SetText(FText::FromString(ObjectiveText));
-			UE_LOG(LogTemp, Warning, TEXT("Number only update: %s"), *ObjectiveText);
+			//UE_LOG(LogTemp, Warning, TEXT("Number only update: %s"), *ObjectiveText);
 		}
 		
 	}
@@ -154,7 +154,7 @@ void UTPlayerUIWidget::UpdateKillCount(int32 CurrentKills,int32 TotalMonsters)
 		FString KillString=FString::Printf(TEXT("Monster: %d/%d"),CurrentKills,TotalMonsters);
 		KillCountText->SetText(FText::FromString(KillString));
 
-		UE_LOG(LogTemp,Warning,TEXT("Kill count updated: %s"), *KillString);
+		//UE_LOG(LogTemp,Warning,TEXT("Kill count updated: %s"), *KillString);
 	}
 }
 
@@ -164,7 +164,7 @@ void UTPlayerUIWidget::ShoWEnemyIncomingAlarm()
 	{
 		WaveAlarmText->SetText(FText::FromString(TEXT("Enemy Incoming!!")));
 		WaveAlarmText->SetVisibility(ESlateVisibility::Visible);
-		UE_LOG(LogTemp,Warning,TEXT("Enemy Incoming alram shown!!"));
+		//UE_LOG(LogTemp,Warning,TEXT("Enemy Incoming alram shown!!"));
 	}
 }
 
@@ -173,7 +173,9 @@ void UTPlayerUIWidget::HideEnemyIncomingAlarm()
 	if (WaveAlarmText)
 	{
 		WaveAlarmText->SetVisibility(ESlateVisibility::Hidden);
-		UE_LOG(LogTemp,Warning,TEXT("Enemy Incoming alarm hidden!!"));
+		WaveAlarmText->SetText(FText::FromString(TEXT(""))); //문구까지 초기화
+		
+		//UE_LOG(LogTemp,Warning,TEXT("Enemy Incoming alarm hidden!!"));
 	}
 }
 
@@ -198,7 +200,7 @@ void UTPlayerUIWidget::StartTypingAnimation(const FString& FullText)
 		true
 		);
 
-	UE_LOG(LogTemp,Warning,TEXT("Started typing animation for: %s"), *FullText);
+	//UE_LOG(LogTemp,Warning,TEXT("Started typing animation for: %s"), *FullText);
 	
 }
 
@@ -211,7 +213,7 @@ void UTPlayerUIWidget::UpdateTypingText()
 		GetWorld()->GetTimerManager().ClearTimer(TypingTimerHandle);
 		CurrentDisplayText=TargetText;
 		ObjectText->SetText(FText::FromString(CurrentDisplayText));
-		UE_LOG(LogTemp,Warning,TEXT("Typing animation completed"));
+		//UE_LOG(LogTemp,Warning,TEXT("Typing animation completed"));
 		return;
 	}
 	// 한 글자씩 추가
@@ -224,7 +226,7 @@ void UTPlayerUIWidget::StartFlashingAndChangeText(const FString& NewText)
 {
 	if (!ObjectText) return;
 
-	UE_LOG(LogTemp,Warning,TEXT("Starting flash effect for mission change"));
+	//UE_LOG(LogTemp,Warning,TEXT("Starting flash effect for mission change"));
 
 	// 깜빡임 시작
 	GetWorld()->GetTimerManager().SetTimer(
@@ -271,7 +273,7 @@ void UTPlayerUIWidget::StopFlashing()
 		ObjectText->SetColorAndOpacity(FSlateColor(FLinearColor::White));
 	}
 
-	UE_LOG(LogTemp,Warning,TEXT("Flash effect stopped"));
+	//UE_LOG(LogTemp,Warning,TEXT("Flash effect stopped"));
 }
 
 bool UTPlayerUIWidget::IsRealMissionChange(const FString& OldText, const FString& NewText)
@@ -279,7 +281,7 @@ bool UTPlayerUIWidget::IsRealMissionChange(const FString& OldText, const FString
 
 	if (OldText==TEXT("Mission:")&& NewText != TEXT("Mission:"))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("Mission initialization: 'Mission:' -> '%s' = REAL CHANGE"), *NewText);
+		//UE_LOG(LogTemp, Warning, TEXT("Mission initialization: 'Mission:' -> '%s' = REAL CHANGE"), *NewText);
 		return true;
 	}
 
@@ -323,11 +325,11 @@ void UTPlayerUIWidget::UpdateWeaponName(const FString& WeaponName)
 	if (WeaponNameText)
 	{
 		WeaponNameText->SetText(FText::FromString(WeaponName));
-		UE_LOG(LogTemp,Warning,TEXT("Weapon name updated: %s"),*WeaponName);
+		//UE_LOG(LogTemp,Warning,TEXT("Weapon name updated: %s"),*WeaponName);
 	}
 	else
 	{
-		UE_LOG(LogTemp,Error,TEXT("WeaponNameText is NULL! Check widget binding,"));
+		//UE_LOG(LogTemp,Error,TEXT("WeaponNameText is NULL! Check widget binding,"));
 	}
 	
 }

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -15,6 +15,7 @@
 #include "Engine/Engine.h"
 #include "UnifiedBuffer.h"
 
+
 void UTUIManager::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
@@ -135,10 +136,23 @@ void UTUIManager::SetPlayerCharacter(ATCharacterBase* PlayerChar)
 
 void UTUIManager::UpdatePlayerHP()
 {
-	if (PlayerUIWidget && PlayerCharacter)
+	//활성화된 플레이어 캐릭터 가져오기
+	if (APlayerController* PC=GetWorld()->GetFirstPlayerController())
 	{
-		PlayerUIWidget->UpdateHPBar(PlayerCharacter->GetCurrentHP(),PlayerCharacter->GetMaxHP());
+		if (APawn* CurrentPawn=PC->GetPawn())
+		{
+			if (ATPlayerCharacter*CurrentPlayer=Cast<ATPlayerCharacter>(CurrentPawn))
+			{
+				float CurrentHP=CurrentPlayer->GetCurrentHP();
+				float MaxHP=CurrentPlayer->GetMaxHP();
+				PlayerUIWidget->UpdateHPBar(CurrentHP,MaxHP);
+
+				return;
+			}
+		}
 	}
+	// 플레이어를 찾지 못했을 때
+	UE_LOG(LogTemp, Error, TEXT("❌ UpdatePlayerHP: No valid player found"));
 }
 
 void UTUIManager::UpdatePlayerAmmo()
@@ -550,6 +564,12 @@ void UTUIManager::UpdateMonsterStatus()
    
     if (!bWaveActive && !bWaveCompleted)
     {
+
+    	UE_LOG(LogTemp, Warning, TEXT("🔍 Checking wave start conditions:"));
+    	UE_LOG(LogTemp, Warning, TEXT("  bGameModeWaveActive: %s"), bGameModeWaveActive ? TEXT("YES") : TEXT("NO"));
+    	UE_LOG(LogTemp, Warning, TEXT("  bAnySpawnerActive: %s"), bAnySpawnerActive ? TEXT("YES") : TEXT("NO"));
+    	UE_LOG(LogTemp, Warning, TEXT("  CurrentMonsterCount: %d"), CurrentMonsterCount)
+    	
         // 조건 1: GameMode나 스포너에서 웨이브 시작
         // 조건 2: 필드에 몬스터가 있으면 즉시 시작 (새로 추가!)
         if (bGameModeWaveActive || bAnySpawnerActive || CurrentMonsterCount > 0)
@@ -667,8 +687,8 @@ void UTUIManager::FindAllMonstersInWorld()
 			if (Monster)
 			{
 				float HP = Monster->GetCurrentHP();
-				UE_LOG(LogTemp, Warning, TEXT("🔍 Found Monster: %s (HP: %.1f)"), 
-					   *Monster->GetName(), HP);
+				// UE_LOG(LogTemp, Warning, TEXT("🔍 Found Monster: %s (HP: %.1f)"), 
+				// 	   *Monster->GetName(), HP);
                 
 				if (HP > 0)
 				{
@@ -678,8 +698,8 @@ void UTUIManager::FindAllMonstersInWorld()
 			}
 		}
         
-		UE_LOG(LogTemp, Warning, TEXT("🔍 Monster Search Results: %d total found, %d alive"), 
-			   TotalFound, AliveCount);
+		// UE_LOG(LogTemp, Warning, TEXT("🔍 Monster Search Results: %d total found, %d alive"), 
+		// 	   TotalFound, AliveCount);
 	}
 }
 
@@ -887,7 +907,7 @@ void UTUIManager::RespawnGameUI()
 
 void UTUIManager::RestartGameUI()
 {
-	UE_LOG(LogTemp,Warning,TEXT("Resetting Game UI..."));
+	UE_LOG(LogTemp,Error,TEXT("Resetting Game UI..."));
 
 	//미션 관련 변수 초기화
 	bWaveActive=false;
@@ -942,6 +962,62 @@ void UTUIManager::RestartGameUI()
 
 		// 알람 숨기기
 		PlayerUIWidget->HideEnemyIncomingAlarm();
+
+		// 🔧 실제 플레이어 정보로 업데이트
+		if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+		{
+			if (APawn* PlayerPawn = PC->GetPawn()) //지역변수명 다르게
+			{
+				if (ATPlayerCharacter* Player = Cast<ATPlayerCharacter>(PlayerPawn))
+				{
+					// 실제 플레이어 체력으로 업데이트
+					float CurrentHealth = Player->GetCurrentHP();
+					float MaxHealth = Player->GetMaxHP();
+					PlayerUIWidget->UpdateHPBar(CurrentHealth, MaxHealth);
+            
+					UE_LOG(LogTemp, Warning, TEXT("🔧 Health updated from player: %.1f/%.1f"), 
+						   CurrentHealth, MaxHealth);
+
+					// 🔧 플레이어가 가진 무기 정보 업데이트
+					ATWeaponBase* PlayerWeapon = Player->GetCurrentWeapon();
+					if (PlayerWeapon)
+					{
+						// 무기 탄약 정보 업데이트
+						int32 CurrentAmmo = PlayerWeapon->GetCurrentAmmo();
+						int32 TotalAmmo = PlayerWeapon->GetTotalAmmo();
+						PlayerUIWidget->UpdateAmmoInfo(CurrentAmmo, TotalAmmo);
+                
+						// 무기 이름 업데이트
+						FString WeaponName = PlayerWeapon->GetWeaponTypeString();
+						PlayerUIWidget->UpdateWeaponName(WeaponName);
+                
+						UE_LOG(LogTemp, Warning, TEXT("🔧 Weapon updated: %s (%d/%d)"), 
+							   *WeaponName, CurrentAmmo, TotalAmmo);
+					}
+					else
+					{
+						// 무기가 없다면 기본값 (권총 7/100)
+						PlayerUIWidget->UpdateAmmoInfo(7, 100);
+						PlayerUIWidget->UpdateWeaponName(TEXT("Pistol"));
+						UE_LOG(LogTemp, Warning, TEXT("🔧 No weapon found, using default pistol (7/100)"));
+					}
+				}
+				else
+				{
+					UE_LOG(LogTemp, Error, TEXT("❌ Failed to cast to ATPlayerCharacter"));
+				}
+			}
+			else
+			{
+				UE_LOG(LogTemp, Error, TEXT("❌ PlayerPawn is NULL"));
+			}
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("❌ Failed to get PlayerController for UI update"));
+		}
+
+		
 	}
 
 	
@@ -952,18 +1028,31 @@ void UTUIManager::RestartGameUI()
 		GetWorld()->GetTimerManager().ClearTimer(UIUpdateTimerHandle);
 		GetWorld()->GetTimerManager().ClearTimer(HitDetectionTimer);
 
-		//모니터링 재시작
-		StartMonitoringMonsters();
-		StartHitDetection();
-
-		//UI업데이트 타이머 재시작
+		//잠시 지연후 재시작
+		FTimerHandle DelayTimer;
 		GetWorld()->GetTimerManager().SetTimer(
-			UIUpdateTimerHandle,
-			this,
-			&UTUIManager::UpdateAllUI,
+			DelayTimer,
+			[this]()
+			{
+				//모니터링 재시작
+		          StartMonitoringMonsters();
+		           StartHitDetection();
+
+		           //UI업데이트 타이머 재시작
+		          GetWorld()->GetTimerManager().SetTimer(
+			      UIUpdateTimerHandle,
+			      this,
+			       &UTUIManager::UpdateAllUI,
 			0.1f,
 			true
 			);
+				UE_LOG(LogTemp, Warning, TEXT("✅ Monitoring systems restarted after delay"));
+			},
+			0.5f,
+			false
+			);
+
+		
 	}
 
 	//스포너 재등록 및 웨이브 정보 업데이트

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -159,7 +159,8 @@ void UTUIManager::UpdatePlayerAmmo()
 {
 	if (PlayerUIWidget && CurrentWeapon)
 	{
-		PlayerUIWidget->UpdateAmmoInfo(CurrentWeapon->GetCurrentAmmo(),CurrentWeapon->GetTotalAmmo());
+		PlayerUIWidget->UpdateAmmoInfo(
+			CurrentWeapon->GetCurrentAmmo(),CurrentWeapon->GetTotalAmmo());
 	}
 }
 

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -847,62 +847,62 @@ void UTUIManager::UpdateAllUI()
     }
 }
 
-void UTUIManager::RespawnGameUI()
-{
-	UE_LOG(LogTemp, Warning, TEXT("🔄 Player Respawning - Updating UI..."));
-
-	//리스폰 시에는 게임 진행상황은 유지, 플레이어 관련만 초기화
-
-	if (PlayerUIWidget)
-	{
-		//플레이어 HP 초기화 (최대 HP로 복구)
-		if (PlayerCharacter)
-		{
-			float MaxHP=PlayerCharacter->GetMaxHP();
-			PlayerUIWidget->UpdateHPBar(MaxHP,MaxHP);
-		}
-		
-		// 무기 정보 갱신 (현재 무기 상태 반영)
-		if (ATPlayerCharacter* PC=Cast<ATPlayerCharacter>(PlayerCharacter))
-		{
-			CurrentWeapon=PC->CurrentWeapon;
-			if (CurrentWeapon)
-			{
-				//탄약 정보 업데이트
-				PlayerUIWidget->UpdateAmmoInfo(CurrentWeapon->GetCurrentAmmo(),CurrentWeapon->GetTotalAmmo());
-
-				//무기 이름 업데이트
-				FString WeaponName=CurrentWeapon->GetWeaponTypeString();
-				PlayerUIWidget->UpdateWeaponName(WeaponName);
-
-				//test log
-				UE_LOG(LogTemp,Warning,TEXT("Weapon info updated: %s"),*WeaponName);
-				
-			}
-		}
-
-		// 점령 UI 상태 갱신 (플레이어가 죽기전에 거점 근처에 있엇다면)
-		if (CurrentCapturePoint && CurrentCapturePoint->bPlayerInArea)
-		{
-			ShowCaptureUI(CapturePointName);
-			float ProgressPercent=CurrentCapturePoint->CapturePercent/100.0f;
-			UpdateCaptureProgress(ProgressPercent);
-		}
-		else
-		{
-			HideCaptureUI();
-		}
-
-		//알람 UI 갱신
-		PlayerUIWidget->HideEnemyIncomingAlarm();
-	}
-
-	// 현재 미션 상태 재확인 (게임 진행상황에 맞게)
-	UpdateMissionState();
-
-	UE_LOG(LogTemp, Warning, TEXT("✅ Player Respawn UI Update Complete!"));
-	
-}
+// void UTUIManager::RespawnGameUI() // 시간 문제로 연결못함
+// {
+// 	UE_LOG(LogTemp, Warning, TEXT("🔄 Player Respawning - Updating UI..."));
+//
+// 	//리스폰 시에는 게임 진행상황은 유지, 플레이어 관련만 초기화
+//
+// 	if (PlayerUIWidget)
+// 	{
+// 		//플레이어 HP 초기화 (최대 HP로 복구)
+// 		if (PlayerCharacter)
+// 		{
+// 			float MaxHP=PlayerCharacter->GetMaxHP();
+// 			PlayerUIWidget->UpdateHPBar(MaxHP,MaxHP);
+// 		}
+// 		
+// 		// 무기 정보 갱신 (현재 무기 상태 반영)
+// 		if (ATPlayerCharacter* PC=Cast<ATPlayerCharacter>(PlayerCharacter))
+// 		{
+// 			CurrentWeapon=PC->CurrentWeapon;
+// 			if (CurrentWeapon)
+// 			{
+// 				//탄약 정보 업데이트
+// 				PlayerUIWidget->UpdateAmmoInfo(CurrentWeapon->GetCurrentAmmo(),CurrentWeapon->GetTotalAmmo());
+//
+// 				//무기 이름 업데이트
+// 				FString WeaponName=CurrentWeapon->GetWeaponTypeString();
+// 				PlayerUIWidget->UpdateWeaponName(WeaponName);
+//
+// 				//test log
+// 				UE_LOG(LogTemp,Warning,TEXT("Weapon info updated: %s"),*WeaponName);
+// 				
+// 			}
+// 		}
+//
+// 		// 점령 UI 상태 갱신 (플레이어가 죽기전에 거점 근처에 있엇다면)
+// 		if (CurrentCapturePoint && CurrentCapturePoint->bPlayerInArea)
+// 		{
+// 			ShowCaptureUI(CapturePointName);
+// 			float ProgressPercent=CurrentCapturePoint->CapturePercent/100.0f;
+// 			UpdateCaptureProgress(ProgressPercent);
+// 		}
+// 		else
+// 		{
+// 			HideCaptureUI();
+// 		}
+//
+// 		//알람 UI 갱신
+// 		PlayerUIWidget->HideEnemyIncomingAlarm();
+// 	}
+//
+// 	// 현재 미션 상태 재확인 (게임 진행상황에 맞게)
+// 	UpdateMissionState();
+//
+// 	UE_LOG(LogTemp, Warning, TEXT("✅ Player Respawn UI Update Complete!"));
+// 	
+// }
 
 
 void UTUIManager::RestartGameUI()

--- a/Source/Team02/UI/InGame/TUIManager.cpp
+++ b/Source/Team02/UI/InGame/TUIManager.cpp
@@ -361,7 +361,6 @@ void UTUIManager::UpdateMissionProgress()
 	UpdateMissionState();
 }
 
-// TUIManager.cpp의 UpdateMissionState() 함수를 이것으로 교체하세요
 
 void UTUIManager::UpdateMissionState()
 {
@@ -405,7 +404,7 @@ void UTUIManager::UpdateMissionState()
     // 두 번째 무기 습득 단계 (첫 번째 무기 습득 후, 2거점 가기 전)
     else if (bWeaponPickedUp && !bSecondWeaponPickedUp && CurrentCaptureIndex == 1)
     {
-        NewObjective = TEXT("Get Rifle");  // 새로 추가
+        NewObjective = TEXT("Get RailGun");  // 새로 추가
     }
     // 첫 번째 무기 습득 단계 (1거점 완료 후)
     else if (bFirstCaptureCompleted && !bWeaponPickedUp)

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -12,6 +12,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnVictoryDelegate);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnGameOverDelegate);
 
 class ATCharacterBase;
+class ATPlayerCharacter;
 class ATWeaponBase;
 class ATAIBossMonster;
 class ATGameMode;

--- a/Source/Team02/UI/InGame/TUIManager.h
+++ b/Source/Team02/UI/InGame/TUIManager.h
@@ -98,8 +98,8 @@ public:
 	void UnlockWeapon();
 
 	//게임 리스폰, 리스타트 UI 함수
-	UFUNCTION(BlueprintCallable)
-	void RespawnGameUI();
+	// UFUNCTION(BlueprintCallable)
+	// void RespawnGameUI();
 	
 	UFUNCTION(BlueprintCallable)
 	void RestartGameUI();


### PR DESCRIPTION
---

변경 사항 설명

이 풀 리퀘스트에는 다음 내용이 포함됩니다:

구식 리스폰 UI 업데이트 로직 및 관련 RespawnGameUI 함수 제거

UI 전면 개편 및 재구성:

기존 HPBar 에셋을 새 구조의 에셋(HP_Bar_Progress, HPBar_1_1)으로 교체

WBP_PlayerUI와 MainLevel을 개선하여 사용성 향상

LABDigital 전용 에셋 통합

탄약 UI 개선(가독성 향상):

무제한 탄약일 경우 "infinity"가 표시되도록 UpdateAmmoInfo 수정

관련 위젯과 신규 UI 에셋 포함 및 수정

게임 재시작 및 몬스터 초기화 로직 제거 및 재구현:

기존 RestartCurrentGame 및 SaveInitialEnemyPositions 함수 삭제

UI와 몬스터 초기화를 개선한 새로운 RestartCurrentGame 함수 추가

관련 클래스 및 구조 최적화 및 정리